### PR TITLE
Fix wordcloud component not rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,9 @@
     "vuex": "^3.6.2",
     "winston": "^2.4.5"
   },
+  "resolutions": {
+    "d3-selection": "1.3.0"
+  },
   "browserslist": [
     "defaults",
     "not IE 11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3511,12 +3511,7 @@ d3-scale@1.0.7:
     d3-time "1"
     d3-time-format "2"
 
-d3-selection@1, d3-selection@^1.1.0:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.2.tgz#dcaa49522c0dbf32d6c1858afc26b6094555bc5c"
-  integrity sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==
-
-d3-selection@1.3.0:
+d3-selection@1, d3-selection@1.3.0, d3-selection@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.3.0.tgz#d53772382d3dc4f7507bfb28bcd2d6aed2a0ad6d"
   integrity sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA==


### PR DESCRIPTION
On the current development branch, the wordcloud for showing free response results is not rendering. The issue is related to a vue-wordcloud package dependency on d3, specificially d3 transitions. 

This PR specifies that the version for the `d3-selection` package resolution in package.json, and updates the yarn.lock file.

Resolves #72.
