### PR TITLE
Remove container on navbar

### DIFF
--- a/resources/assets/js/components/Navbar.vue
+++ b/resources/assets/js/components/Navbar.vue
@@ -1,6 +1,5 @@
 <template>
     <nav class="navbar navbar-expand-lg navbar-light bg-light align-center">
-        <div class="container">
         <router-link v-if="title" :to="link" class="navbar-brand">{{ title }}</router-link>
         
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
@@ -24,10 +23,7 @@
                             </a>
                 </li>
             </ul>
-            </div>
-
         </div>
-
     </nav>
 
 </template>


### PR DESCRIPTION
Reverts to no container on navbar.

<img width="733" alt="Screen Shot 2021-10-26 at 2 17 41 PM" src="https://user-images.githubusercontent.com/980170/138946979-4025d72b-cf0d-4ef8-8be2-9d7ae1a5af5a.png">

Resolves #69 