### PR TITLE
Add left padding to folder name

### DIFF
--- a/resources/assets/js/components/chime_components/FolderCard.vue
+++ b/resources/assets/js/components/chime_components/FolderCard.vue
@@ -105,10 +105,20 @@ a:hover {
   padding: 0.5rem;
   padding-left: 1rem;
 }
+/** 
+* drag handle appears with more than one card.
+* reduce the left-padding on the wrapper
+*/
+.folder-card__drag-handle + .folder-card__name-wrapper {
+  padding-left: 0.5rem;
+}
+
 .folder-card__name-wrapper {
-  padding: 1.5rem 0.5rem;
+  padding: 1.5rem 1rem 1.5rem 1.5rem;
   flex-grow: 1;
 }
+
+
 .folder-card__name {
   margin: 0;
   font-size: 1.5rem;


### PR DESCRIPTION
This adds left padding to the folder name on the chime page when there is a single folder.

## One folder
<img width="400" alt="Screen Shot 2021-10-26 at 2 47 30 PM" src="https://user-images.githubusercontent.com/980170/138950358-70904f5f-6016-4976-ad88-d4bc07aa8d42.png">

## Multiple folders
<img width="400" alt="Screen Shot 2021-10-26 at 2 40 33 PM" src="https://user-images.githubusercontent.com/980170/138950030-7fa4fd44-f847-453a-bf7b-6824b57264c7.png">

Lmk if this works.

Resolves #68.