### PR TITLE
Fix failing slider test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,10 +54,3 @@ jobs:
         with:
           name: cypress-screenshots
           path: cypress/screenshots
-
-      - name: Upload test videos
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: cypress-videos
-          path: cypress/videos

--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "http://localhost",
   "testFiles": "**/*.{test,spec}.js",
-  "video": true,
+  "video": false,
   "viewportWidth": 1920,
   "viewportHeight": 1080,
   "matchImageSnapshot": {

--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "http://localhost",
   "testFiles": "**/*.{test,spec}.js",
-  "video": false,
+  "video": true,
   "viewportWidth": 1920,
   "viewportHeight": 1080,
   "matchImageSnapshot": {

--- a/cypress/integration/ui/question.test.js
+++ b/cypress/integration/ui/question.test.js
@@ -386,6 +386,13 @@ describe("question", () => {
       let testChime;
       let testFolder;
 
+      // listen for participant responses
+      // so that we can wait for them to complete
+      cy.intercept({
+        method: "PUT",
+        url: "/api/**/response",
+      }).as("participantResponse");
+
       api
         .createChime({ name: "Test Chime" })
         .then((chime) => {
@@ -424,6 +431,7 @@ describe("question", () => {
           cy.get("[data-cy=slider-response-input]")
             .invoke("val", 25)
             .trigger("change");
+          cy.wait("@participantResponse", { requestTimeout: 3000 });
         })
         .then(() => {
           // login as faculty
@@ -551,7 +559,7 @@ describe("question", () => {
           cy.get("@image-heatmap-target").click(50, 100);
         })
         .then(() => {
-          cy.wait("@heatmapResponse");
+          cy.wait("@heatmapResponse", { requestTimeout: 10000 });
           // check that the circle appears on user interface
           cy.get("@image-heatmap-target").matchImageSnapshot(
             `image-heatmap-response-view_1920x1080`

--- a/cypress/integration/ui/question.test.js
+++ b/cypress/integration/ui/question.test.js
@@ -227,7 +227,7 @@ describe("question", () => {
           cy.login("faculty");
           cy.visit(`/chime/${testChime.id}/folder/${testFolder.id}`);
           cy.get("[data-cy=present-question-button]").click();
-          cy.get("[data-cy=show-results-button").click();
+          cy.get("[data-cy=show-results-button]").click();
 
           // "Guest" and "response" should be in the SVG word cloud
           cy.get("[data-cy=word-cloud]")
@@ -288,7 +288,7 @@ describe("question", () => {
           cy.login("faculty");
           cy.visit(`/chime/${testChime.id}/folder/${testFolder.id}`);
           cy.get("[data-cy=present-question-button]").click();
-          cy.get("[data-cy=show-results-button").click();
+          cy.get("[data-cy=show-results-button]").click();
 
           // the "h" in "feel the heat" should be highlighted redish
           cy.get(":nth-child(140)").should(
@@ -368,7 +368,7 @@ describe("question", () => {
           cy.login("faculty");
           cy.visit(`/chime/${testChime.id}/folder/${testFolder.id}`);
           cy.get("[data-cy=present-question-button]").click();
-          cy.get("[data-cy=show-results-button").click();
+          cy.get("[data-cy=show-results-button]").click();
 
           // expect goldy image to be displayed
           // just checking extension for now, as name could have changed
@@ -385,6 +385,10 @@ describe("question", () => {
     it("creates a qualitative slider question and lets participant respond", () => {
       let testChime;
       let testFolder;
+
+      cy.intercept({
+        method: "POST",
+      });
 
       api
         .createChime({ name: "Test Chime" })
@@ -420,7 +424,7 @@ describe("question", () => {
 
           // as a guest, record a response
           cy.visit(`/join/${testChime.access_code}`);
-          cy.get("[data-cy=slider-response-input")
+          cy.get("[data-cy=slider-response-input]")
             .invoke("val", 25)
             .trigger("change");
 
@@ -428,10 +432,10 @@ describe("question", () => {
           cy.login("faculty");
           cy.visit(`/chime/${testChime.id}/folder/${testFolder.id}`);
           cy.get("[data-cy=present-question-button]").click();
-          cy.get("[data-cy=show-results-button").click();
+          cy.get("[data-cy=show-results-button]").click();
 
           // expect the labels to be displayed
-          cy.get("[data-cy=chart-container")
+          cy.get("[data-cy=chart-container]")
             .contains("svg", "Bad")
             .contains("svg", "Good");
 
@@ -560,7 +564,7 @@ describe("question", () => {
           cy.login("faculty");
           cy.visit(`/chime/${testChime.id}/folder/${testFolder.id}`);
           cy.get("[data-cy=present-question-button]").click();
-          cy.get("[data-cy=show-results-button").click();
+          cy.get("[data-cy=show-results-button]").click();
 
           // to make it easier for tests to see, make img behind heatmap
           // transparent

--- a/cypress/integration/ui/question.test.js
+++ b/cypress/integration/ui/question.test.js
@@ -386,10 +386,6 @@ describe("question", () => {
       let testChime;
       let testFolder;
 
-      cy.intercept({
-        method: "POST",
-      });
-
       api
         .createChime({ name: "Test Chime" })
         .then((chime) => {
@@ -421,13 +417,15 @@ describe("question", () => {
 
           // logout faculty, become guest user
           cy.logout();
-
+        })
+        .then(() => {
           // as a guest, record a response
           cy.visit(`/join/${testChime.access_code}`);
           cy.get("[data-cy=slider-response-input]")
             .invoke("val", 25)
             .trigger("change");
-
+        })
+        .then(() => {
           // login as faculty
           cy.login("faculty");
           cy.visit(`/chime/${testChime.id}/folder/${testFolder.id}`);

--- a/cypress/integration/ui/question.test.js
+++ b/cypress/integration/ui/question.test.js
@@ -430,7 +430,13 @@ describe("question", () => {
           cy.visit(`/join/${testChime.access_code}`);
           cy.get("[data-cy=slider-response-input]")
             .invoke("val", 25)
-            .trigger("change");
+            .then(($input) => { 
+              // using native event triggering rather
+              // than `.trigger`.
+              // see: https://github.com/cypress-io/cypress/issues/1570
+
+              $input[0].dispatchEvent(new Event('change'));
+            });
           cy.wait("@participantResponse", { requestTimeout: 3000 });
         })
         .then(() => {

--- a/resources/assets/js/components/presentation_components/SliderStatistics.vue
+++ b/resources/assets/js/components/presentation_components/SliderStatistics.vue
@@ -41,11 +41,6 @@ export default {
             response_search: '',
             options: {
                 height: "100%",
-                animation:{
-                    duration: 1000,
-                    easing: 'out',
-                    "startup":  false
-                },
                 legend: {
                     position: "none"
                 },


### PR DESCRIPTION
The slider test fails on CI. This PR adds an intercept and an explicit wait for `PUT` request to `/api/**/response`, which seems to resolve the issue.

## Discussion

I've been unable to replicate the issue locally, but in the CI screenshot of failing tests, it appears that the tall bar is the middle bar (bar 8), rather than the expected bar (bar 5).

![question -- slider -- creates a qualitative slider question and lets participant respond (failed)](https://user-images.githubusercontent.com/980170/140094511-8230daed-6e4d-486d-86f1-746f80448582.png)

My working hypothesis is that there's a race condition between the response sent by the participant and when the response is displayed in the presenter view. I'm also wondering if animation timing plays into this as well... when a new response is received the chart is redrawn and bars slide in from the right.  I could imagine a case where the tests are selecting the bars during the draw.

The working fix is to listen for the PUT response

```js
cy.intercept({
  method: "PUT",
  url: "/api/**/response",
}).as("participantResponse");
```

and the wait for the response to complete after invoking the slider change:

```js
 cy.get("[data-cy=slider-response-input]")
   .invoke("val", 25)
   .trigger("change");
cy.wait("@participantResponse", { requestTimeout: 3000 });
```

I'm not sure if this resolves the actual cause or just puts enough wait in to make the race condition less likely.

## Additional changes:
- disable cypress video capture on CI. It drops too many frames to be useful on CI, meanwhile adding to test length.
- fix typos in question tests. A lot of `[data-cy=...` selectors were missing the closing `]` brace.
