### PR TITLE
ci: :construction_worker: Add snapshot uploads to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,3 +54,10 @@ jobs:
         with:
           name: cypress-screenshots
           path: cypress/screenshots
+
+      - name: Upload snapshots
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: cypress-snapshots
+          path: cypress/snapshots


### PR DESCRIPTION
Always include image snapshots in CI runs.

When passing, we can use images generated by CI if we need to make image updates.
When failing, helpful for troubleshooting the issue.
