### PR TITLE
Feature/78 make showing join instructions the default

### DIFF
--- a/app/Chime.php
+++ b/app/Chime.php
@@ -14,6 +14,10 @@ class Chime extends Model
     use SoftDeletes, CascadeSoftDeletes;
     
     protected $fillable = ['name', 'access_code', 'require_login', 'students_can_view', 'join_instructions', 'only_correct_answers_lti', 'resource_link_pk', 'lti_grade_mode', 'show_folder_title_to_participants'];
+
+    protected $attributes = [
+        'join_instructions' => true,
+    ];
     
     protected $dates = ['deleted_at'];
     protected $cascadeDeletes = ['folders'];

--- a/cypress/integration/ui/chime.test.js
+++ b/cypress/integration/ui/chime.test.js
@@ -137,11 +137,8 @@ describe("chime UI", () => {
         cy.get(".title").should("contain.text", "Login to Continue");
       });
 
-      it("displays join instructions when presenting", () => {
-        cy.get("#joinInstructions").check();
+      it("displays join instructions when presenting (by default)", () => {
         cy.visit(`/chime/${testChime.id}/folder/${testFolder.id}/present`);
-
-        // FIXME: This text is in the navbar and will be hidden on small screens
         cy.get("[data-cy=show-join-code]").should(
           "contain.text",
           toHyphenatedCode(testChime.access_code)

--- a/resources/assets/js/components/chime_components/ChimeManagementOptions.vue
+++ b/resources/assets/js/components/chime_components/ChimeManagementOptions.vue
@@ -2,6 +2,14 @@
     <ul>
         <li>
             <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="joinInstructions" id="joinInstructions"
+                    v-model="join_instructions_local" @change="$emit('update:join_instructions', $event.target.checked)">
+                <label class="form-check-label" for="joinInstructions">Display "join" instructions when
+                    presenting</label>
+            </div>
+        </li>
+        <li>
+            <div class="form-check">
                 <input class="form-check-input" type="checkbox" name="requireLogin" id="requireLogin" v-model="require_login_local"
                     @change="$emit('update:require_login', $event.target.checked);">
                 <label class="form-check-label" for="requireLogin">Require Login to Join or Access</label>
@@ -12,14 +20,6 @@
                 <input class="form-check-input" type="checkbox" name="studentView" id="studentView" v-model="students_can_view_local"
                     @change="$emit('update:students_can_view', $event.target.checked)">
                 <label class="form-check-label" for="studentView">Participants can view results</label>
-            </div>
-        </li>
-        <li>
-            <div class="form-check">
-                <input class="form-check-input" type="checkbox" name="joinInstructions" id="joinInstructions"
-                    v-model="join_instructions_local" @change="$emit('update:join_instructions', $event.target.checked)">
-                <label class="form-check-label" for="joinInstructions">Display "join" instructions when
-                    presenting</label>
             </div>
         </li>
         <li>

--- a/resources/assets/js/components/home_components/ChimePanel.vue
+++ b/resources/assets/js/components/home_components/ChimePanel.vue
@@ -57,7 +57,7 @@ export default {
         return {
             requireLogin: false,
             studentsCanView: false,
-            joinInstructions: false,
+            joinInstructions: true,
             chimes: [],
             showAdd: false,
             chime_name: "",


### PR DESCRIPTION
- Turns on "Show Join Instructions" by default for new chimes.
- Changes this to be the first option. It looked a bit weird when this was only option checked by default and it was in the middle of the other unchecked options.
- Updates tests

Part of #78.