### PR TITLE
add laravel-ide-helper as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
   "require-dev": {
     "appzcoder/crud-generator": "^3.0",
     "barryvdh/laravel-debugbar": "^3.2",
+    "barryvdh/laravel-ide-helper": "^2.10",
     "deployer/recipes": "^6.1",
     "filp/whoops": "~2.0",
     "fzaninotto/faker": "~1.4",
@@ -90,6 +91,10 @@
     "post-autoload-dump": [
       "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
       "@php artisan package:discover"
+    ],
+    "post-update-cmd": [
+      "Illuminate\\Foundation\\ComposerScripts::postUpdate",
+      "@php artisan ide-helper:generate"
     ]
   },
   "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "dada4417f1c641672a5378fb3b7412aa",
+  "content-hash": "4fde2ac0603db575d4c0e28186ef647e",
   "packages": [
     {
       "name": "brick/math",
@@ -7047,6 +7047,568 @@
       "time": "2021-01-06T14:21:44+00:00"
     },
     {
+      "name": "barryvdh/laravel-ide-helper",
+      "version": "v2.10.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/barryvdh/laravel-ide-helper.git",
+        "reference": "73b1012b927633a1b4cd623c2e6b1678e6faef08"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/barryvdh/laravel-ide-helper/zipball/73b1012b927633a1b4cd623c2e6b1678e6faef08",
+        "reference": "73b1012b927633a1b4cd623c2e6b1678e6faef08",
+        "shasum": ""
+      },
+      "require": {
+        "barryvdh/reflection-docblock": "^2.0.6",
+        "composer/composer": "^1.6 || ^2",
+        "doctrine/dbal": "^2.6 || ^3",
+        "ext-json": "*",
+        "illuminate/console": "^8",
+        "illuminate/filesystem": "^8",
+        "illuminate/support": "^8",
+        "nikic/php-parser": "^4.7",
+        "php": "^7.3 || ^8.0",
+        "phpdocumentor/type-resolver": "^1.1.0"
+      },
+      "require-dev": {
+        "ext-pdo_sqlite": "*",
+        "friendsofphp/php-cs-fixer": "^2",
+        "illuminate/config": "^8",
+        "illuminate/view": "^8",
+        "mockery/mockery": "^1.4",
+        "orchestra/testbench": "^6",
+        "phpunit/phpunit": "^8.5 || ^9",
+        "spatie/phpunit-snapshot-assertions": "^3 || ^4",
+        "vimeo/psalm": "^3.12"
+      },
+      "suggest": {
+        "illuminate/events": "Required for automatic helper generation (^6|^7|^8)."
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "2.9-dev"
+        },
+        "laravel": {
+          "providers": ["Barryvdh\\LaravelIdeHelper\\IdeHelperServiceProvider"]
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Barryvdh\\LaravelIdeHelper\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Barry vd. Heuvel",
+          "email": "barryvdh@gmail.com"
+        }
+      ],
+      "description": "Laravel IDE Helper, generates correct PHPDocs for all Facade classes, to improve auto-completion.",
+      "keywords": [
+        "autocomplete",
+        "codeintel",
+        "helper",
+        "ide",
+        "laravel",
+        "netbeans",
+        "phpdoc",
+        "phpstorm",
+        "sublime"
+      ],
+      "support": {
+        "issues": "https://github.com/barryvdh/laravel-ide-helper/issues",
+        "source": "https://github.com/barryvdh/laravel-ide-helper/tree/v2.10.0"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/barryvdh",
+          "type": "github"
+        }
+      ],
+      "time": "2021-04-09T06:17:55+00:00"
+    },
+    {
+      "name": "barryvdh/reflection-docblock",
+      "version": "v2.0.6",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/barryvdh/ReflectionDocBlock.git",
+        "reference": "6b69015d83d3daf9004a71a89f26e27d27ef6a16"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/barryvdh/ReflectionDocBlock/zipball/6b69015d83d3daf9004a71a89f26e27d27ef6a16",
+        "reference": "6b69015d83d3daf9004a71a89f26e27d27ef6a16",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.3.3"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "~4.0,<4.5"
+      },
+      "suggest": {
+        "dflydev/markdown": "~1.0",
+        "erusev/parsedown": "~1.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "2.0.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-0": {
+          "Barryvdh": ["src/"]
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Mike van Riel",
+          "email": "mike.vanriel@naenius.com"
+        }
+      ],
+      "support": {
+        "source": "https://github.com/barryvdh/ReflectionDocBlock/tree/v2.0.6"
+      },
+      "time": "2018-12-13T10:34:14+00:00"
+    },
+    {
+      "name": "composer/ca-bundle",
+      "version": "1.3.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/composer/ca-bundle.git",
+        "reference": "4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/composer/ca-bundle/zipball/4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b",
+        "reference": "4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b",
+        "shasum": ""
+      },
+      "require": {
+        "ext-openssl": "*",
+        "ext-pcre": "*",
+        "php": "^5.3.2 || ^7.0 || ^8.0"
+      },
+      "require-dev": {
+        "phpstan/phpstan": "^0.12.55",
+        "psr/log": "^1.0",
+        "symfony/phpunit-bridge": "^4.2 || ^5",
+        "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-main": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Composer\\CaBundle\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Jordi Boggiano",
+          "email": "j.boggiano@seld.be",
+          "homepage": "http://seld.be"
+        }
+      ],
+      "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+      "keywords": ["cabundle", "cacert", "certificate", "ssl", "tls"],
+      "support": {
+        "irc": "irc://irc.freenode.org/composer",
+        "issues": "https://github.com/composer/ca-bundle/issues",
+        "source": "https://github.com/composer/ca-bundle/tree/1.3.1"
+      },
+      "funding": [
+        {
+          "url": "https://packagist.com",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/composer",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2021-10-28T20:44:15+00:00"
+    },
+    {
+      "name": "composer/composer",
+      "version": "2.1.12",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/composer/composer.git",
+        "reference": "6e3c2b122e0ec41a7e885fcaf19fa15e2e0819a0"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/composer/composer/zipball/6e3c2b122e0ec41a7e885fcaf19fa15e2e0819a0",
+        "reference": "6e3c2b122e0ec41a7e885fcaf19fa15e2e0819a0",
+        "shasum": ""
+      },
+      "require": {
+        "composer/ca-bundle": "^1.0",
+        "composer/metadata-minifier": "^1.0",
+        "composer/semver": "^3.0",
+        "composer/spdx-licenses": "^1.2",
+        "composer/xdebug-handler": "^2.0",
+        "justinrainbow/json-schema": "^5.2.11",
+        "php": "^5.3.2 || ^7.0 || ^8.0",
+        "psr/log": "^1.0 || ^2.0",
+        "react/promise": "^1.2 || ^2.7",
+        "seld/jsonlint": "^1.4",
+        "seld/phar-utils": "^1.0",
+        "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+        "symfony/filesystem": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+        "symfony/finder": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+        "symfony/process": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0"
+      },
+      "require-dev": {
+        "phpspec/prophecy": "^1.10",
+        "symfony/phpunit-bridge": "^4.2 || ^5.0 || ^6.0"
+      },
+      "suggest": {
+        "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
+        "ext-zip": "Enabling the zip extension allows you to unzip archives",
+        "ext-zlib": "Allow gzip compression of HTTP requests"
+      },
+      "bin": ["bin/composer"],
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-main": "2.1-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Composer\\": "src/Composer"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Nils Adermann",
+          "email": "naderman@naderman.de",
+          "homepage": "https://www.naderman.de"
+        },
+        {
+          "name": "Jordi Boggiano",
+          "email": "j.boggiano@seld.be",
+          "homepage": "https://seld.be"
+        }
+      ],
+      "description": "Composer helps you declare, manage and install dependencies of PHP projects. It ensures you have the right stack everywhere.",
+      "homepage": "https://getcomposer.org/",
+      "keywords": ["autoload", "dependency", "package"],
+      "support": {
+        "irc": "ircs://irc.libera.chat:6697/composer",
+        "issues": "https://github.com/composer/composer/issues",
+        "source": "https://github.com/composer/composer/tree/2.1.12"
+      },
+      "funding": [
+        {
+          "url": "https://packagist.com",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/composer",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2021-11-09T15:02:04+00:00"
+    },
+    {
+      "name": "composer/metadata-minifier",
+      "version": "1.0.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/composer/metadata-minifier.git",
+        "reference": "c549d23829536f0d0e984aaabbf02af91f443207"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/composer/metadata-minifier/zipball/c549d23829536f0d0e984aaabbf02af91f443207",
+        "reference": "c549d23829536f0d0e984aaabbf02af91f443207",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^5.3.2 || ^7.0 || ^8.0"
+      },
+      "require-dev": {
+        "composer/composer": "^2",
+        "phpstan/phpstan": "^0.12.55",
+        "symfony/phpunit-bridge": "^4.2 || ^5"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-main": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Composer\\MetadataMinifier\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Jordi Boggiano",
+          "email": "j.boggiano@seld.be",
+          "homepage": "http://seld.be"
+        }
+      ],
+      "description": "Small utility library that handles metadata minification and expansion.",
+      "keywords": ["composer", "compression"],
+      "support": {
+        "issues": "https://github.com/composer/metadata-minifier/issues",
+        "source": "https://github.com/composer/metadata-minifier/tree/1.0.0"
+      },
+      "funding": [
+        {
+          "url": "https://packagist.com",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/composer",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2021-04-07T13:37:33+00:00"
+    },
+    {
+      "name": "composer/semver",
+      "version": "3.2.6",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/composer/semver.git",
+        "reference": "83e511e247de329283478496f7a1e114c9517506"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/composer/semver/zipball/83e511e247de329283478496f7a1e114c9517506",
+        "reference": "83e511e247de329283478496f7a1e114c9517506",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^5.3.2 || ^7.0 || ^8.0"
+      },
+      "require-dev": {
+        "phpstan/phpstan": "^0.12.54",
+        "symfony/phpunit-bridge": "^4.2 || ^5"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-main": "3.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Composer\\Semver\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Nils Adermann",
+          "email": "naderman@naderman.de",
+          "homepage": "http://www.naderman.de"
+        },
+        {
+          "name": "Jordi Boggiano",
+          "email": "j.boggiano@seld.be",
+          "homepage": "http://seld.be"
+        },
+        {
+          "name": "Rob Bast",
+          "email": "rob.bast@gmail.com",
+          "homepage": "http://robbast.nl"
+        }
+      ],
+      "description": "Semver library that offers utilities, version constraint parsing and validation.",
+      "keywords": ["semantic", "semver", "validation", "versioning"],
+      "support": {
+        "irc": "irc://irc.freenode.org/composer",
+        "issues": "https://github.com/composer/semver/issues",
+        "source": "https://github.com/composer/semver/tree/3.2.6"
+      },
+      "funding": [
+        {
+          "url": "https://packagist.com",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/composer",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2021-10-25T11:34:17+00:00"
+    },
+    {
+      "name": "composer/spdx-licenses",
+      "version": "1.5.5",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/composer/spdx-licenses.git",
+        "reference": "de30328a7af8680efdc03e396aad24befd513200"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/de30328a7af8680efdc03e396aad24befd513200",
+        "reference": "de30328a7af8680efdc03e396aad24befd513200",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^5.3.2 || ^7.0 || ^8.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 7"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-main": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Composer\\Spdx\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Nils Adermann",
+          "email": "naderman@naderman.de",
+          "homepage": "http://www.naderman.de"
+        },
+        {
+          "name": "Jordi Boggiano",
+          "email": "j.boggiano@seld.be",
+          "homepage": "http://seld.be"
+        },
+        {
+          "name": "Rob Bast",
+          "email": "rob.bast@gmail.com",
+          "homepage": "http://robbast.nl"
+        }
+      ],
+      "description": "SPDX licenses list and validation library.",
+      "keywords": ["license", "spdx", "validator"],
+      "support": {
+        "irc": "irc://irc.freenode.org/composer",
+        "issues": "https://github.com/composer/spdx-licenses/issues",
+        "source": "https://github.com/composer/spdx-licenses/tree/1.5.5"
+      },
+      "funding": [
+        {
+          "url": "https://packagist.com",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/composer",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2020-12-03T16:04:16+00:00"
+    },
+    {
+      "name": "composer/xdebug-handler",
+      "version": "2.0.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/composer/xdebug-handler.git",
+        "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/84674dd3a7575ba617f5a76d7e9e29a7d3891339",
+        "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^5.3.2 || ^7.0 || ^8.0",
+        "psr/log": "^1 || ^2 || ^3"
+      },
+      "require-dev": {
+        "phpstan/phpstan": "^0.12.55",
+        "symfony/phpunit-bridge": "^4.2 || ^5"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Composer\\XdebugHandler\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "John Stevenson",
+          "email": "john-stevenson@blueyonder.co.uk"
+        }
+      ],
+      "description": "Restarts a process without Xdebug.",
+      "keywords": ["Xdebug", "performance"],
+      "support": {
+        "irc": "irc://irc.freenode.org/composer",
+        "issues": "https://github.com/composer/xdebug-handler/issues",
+        "source": "https://github.com/composer/xdebug-handler/tree/2.0.2"
+      },
+      "funding": [
+        {
+          "url": "https://packagist.com",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/composer",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2021-07-31T17:03:58+00:00"
+    },
+    {
       "name": "deployer/recipes",
       "version": "6.2.2",
       "source": {
@@ -7332,6 +7894,69 @@
       "time": "2020-07-09T08:09:16+00:00"
     },
     {
+      "name": "justinrainbow/json-schema",
+      "version": "5.2.11",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/justinrainbow/json-schema.git",
+        "reference": "2ab6744b7296ded80f8cc4f9509abbff393399aa"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/2ab6744b7296ded80f8cc4f9509abbff393399aa",
+        "reference": "2ab6744b7296ded80f8cc4f9509abbff393399aa",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.3.3"
+      },
+      "require-dev": {
+        "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+        "json-schema/json-schema-test-suite": "1.2.0",
+        "phpunit/phpunit": "^4.8.35"
+      },
+      "bin": ["bin/validate-json"],
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "5.0.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "JsonSchema\\": "src/JsonSchema/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Bruno Prieto Reis",
+          "email": "bruno.p.reis@gmail.com"
+        },
+        {
+          "name": "Justin Rainbow",
+          "email": "justin.rainbow@gmail.com"
+        },
+        {
+          "name": "Igor Wiedler",
+          "email": "igor@wiedler.ch"
+        },
+        {
+          "name": "Robert Schönthal",
+          "email": "seroscho@googlemail.com"
+        }
+      ],
+      "description": "A library to validate a json schema.",
+      "homepage": "https://github.com/justinrainbow/json-schema",
+      "keywords": ["json", "schema"],
+      "support": {
+        "issues": "https://github.com/justinrainbow/json-schema/issues",
+        "source": "https://github.com/justinrainbow/json-schema/tree/5.2.11"
+      },
+      "time": "2021-07-22T09:24:00+00:00"
+    },
+    {
       "name": "laracasts/cypress",
       "version": "1.4.0",
       "source": {
@@ -7382,71 +8007,6 @@
         "source": "https://github.com/laracasts/cypress/tree/1.4.0"
       },
       "time": "2021-06-14T18:56:45+00:00"
-    },
-    {
-      "name": "laravel/dusk",
-      "version": "v6.13.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/laravel/dusk.git",
-        "reference": "59f9febbaf9559a8a744187f38c53bbd425edd93"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/laravel/dusk/zipball/59f9febbaf9559a8a744187f38c53bbd425edd93",
-        "reference": "59f9febbaf9559a8a744187f38c53bbd425edd93",
-        "shasum": ""
-      },
-      "require": {
-        "ext-json": "*",
-        "ext-zip": "*",
-        "illuminate/console": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
-        "nesbot/carbon": "^2.0",
-        "php": "^7.2|^8.0",
-        "php-webdriver/webdriver": "^1.9.0",
-        "symfony/console": "^4.3|^5.0",
-        "symfony/finder": "^4.3|^5.0",
-        "symfony/process": "^4.3|^5.0",
-        "vlucas/phpdotenv": "^3.0|^4.0|^5.0"
-      },
-      "require-dev": {
-        "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^4.16|^5.17.1|^6.12.1",
-        "phpunit/phpunit": "^7.5.15|^8.4|^9.0"
-      },
-      "suggest": {
-        "ext-pcntl": "Used to gracefully terminate Dusk when tests are running."
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "6.x-dev"
-        },
-        "laravel": {
-          "providers": ["Laravel\\Dusk\\DuskServiceProvider"]
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Laravel\\Dusk\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": ["MIT"],
-      "authors": [
-        {
-          "name": "Taylor Otwell",
-          "email": "taylor@laravel.com"
-        }
-      ],
-      "description": "Laravel Dusk provides simple end-to-end testing and browser automation.",
-      "keywords": ["laravel", "testing", "webdriver"],
-      "support": {
-        "issues": "https://github.com/laravel/dusk/issues",
-        "source": "https://github.com/laravel/dusk/tree/v6.13.0"
-      },
-      "time": "2021-02-23T20:28:11+00:00"
     },
     {
       "name": "laravel/sail",
@@ -7775,73 +8335,6 @@
         "source": "https://github.com/phar-io/version/tree/master"
       },
       "time": "2017-03-05T17:38:23+00:00"
-    },
-    {
-      "name": "php-webdriver/webdriver",
-      "version": "1.10.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/php-webdriver/php-webdriver.git",
-        "reference": "cd9290b95b7651d495bd69253d6e3ef469a7f211"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/cd9290b95b7651d495bd69253d6e3ef469a7f211",
-        "reference": "cd9290b95b7651d495bd69253d6e3ef469a7f211",
-        "shasum": ""
-      },
-      "require": {
-        "ext-curl": "*",
-        "ext-json": "*",
-        "ext-zip": "*",
-        "php": "^5.6 || ~7.0 || ^8.0",
-        "symfony/polyfill-mbstring": "^1.12",
-        "symfony/process": "^2.8 || ^3.1 || ^4.0 || ^5.0"
-      },
-      "replace": {
-        "facebook/webdriver": "*"
-      },
-      "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.0",
-        "ondram/ci-detector": "^2.1 || ^3.5 || ^4.0",
-        "php-coveralls/php-coveralls": "^2.4",
-        "php-mock/php-mock-phpunit": "^1.1 || ^2.0",
-        "php-parallel-lint/php-parallel-lint": "^1.2",
-        "phpunit/phpunit": "^5.7 || ^7 || ^8 || ^9",
-        "squizlabs/php_codesniffer": "^3.5",
-        "symfony/var-dumper": "^3.3 || ^4.0 || ^5.0"
-      },
-      "suggest": {
-        "ext-SimpleXML": "For Firefox profile creation"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-main": "1.8.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Facebook\\WebDriver\\": "lib/"
-        },
-        "files": ["lib/Exception/TimeoutException.php"]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": ["MIT"],
-      "description": "A PHP client for Selenium WebDriver. Previously facebook/webdriver.",
-      "homepage": "https://github.com/php-webdriver/php-webdriver",
-      "keywords": [
-        "Chromedriver",
-        "geckodriver",
-        "php",
-        "selenium",
-        "webdriver"
-      ],
-      "support": {
-        "issues": "https://github.com/php-webdriver/php-webdriver/issues",
-        "source": "https://github.com/php-webdriver/php-webdriver/tree/1.10.0"
-      },
-      "time": "2021-02-25T13:38:09+00:00"
     },
     {
       "name": "phpdocumentor/reflection-common",
@@ -8427,6 +8920,49 @@
       "time": "2018-08-09T05:50:03+00:00"
     },
     {
+      "name": "react/promise",
+      "version": "v2.8.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/reactphp/promise.git",
+        "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/reactphp/promise/zipball/f3cff96a19736714524ca0dd1d4130de73dbbbc4",
+        "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.4.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^7.0 || ^6.5 || ^5.7 || ^4.8.36"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "React\\Promise\\": "src/"
+        },
+        "files": ["src/functions_include.php"]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Jan Sorgalla",
+          "email": "jsorgalla@gmail.com"
+        }
+      ],
+      "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+      "keywords": ["promise", "promises"],
+      "support": {
+        "issues": "https://github.com/reactphp/promise/issues",
+        "source": "https://github.com/reactphp/promise/tree/v2.8.0"
+      },
+      "time": "2020-05-12T15:16:56+00:00"
+    },
+    {
       "name": "sebastian/code-unit-reverse-lookup",
       "version": "1.0.2",
       "source": {
@@ -9001,6 +9537,104 @@
       "time": "2016-10-03T07:35:21+00:00"
     },
     {
+      "name": "seld/jsonlint",
+      "version": "1.8.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/Seldaek/jsonlint.git",
+        "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
+        "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^5.3 || ^7.0 || ^8.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+      },
+      "bin": ["bin/jsonlint"],
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Jordi Boggiano",
+          "email": "j.boggiano@seld.be",
+          "homepage": "http://seld.be"
+        }
+      ],
+      "description": "JSON Linter",
+      "keywords": ["json", "linter", "parser", "validator"],
+      "support": {
+        "issues": "https://github.com/Seldaek/jsonlint/issues",
+        "source": "https://github.com/Seldaek/jsonlint/tree/1.8.3"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/Seldaek",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2020-11-11T09:19:24+00:00"
+    },
+    {
+      "name": "seld/phar-utils",
+      "version": "1.1.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/Seldaek/phar-utils.git",
+        "reference": "749042a2315705d2dfbbc59234dd9ceb22bf3ff0"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/749042a2315705d2dfbbc59234dd9ceb22bf3ff0",
+        "reference": "749042a2315705d2dfbbc59234dd9ceb22bf3ff0",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.3"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Seld\\PharUtils\\": "src/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Jordi Boggiano",
+          "email": "j.boggiano@seld.be"
+        }
+      ],
+      "description": "PHAR file format utilities, for when PHP phars you up",
+      "keywords": ["phar"],
+      "support": {
+        "issues": "https://github.com/Seldaek/phar-utils/issues",
+        "source": "https://github.com/Seldaek/phar-utils/tree/1.1.2"
+      },
+      "time": "2021-08-19T21:01:38+00:00"
+    },
+    {
       "name": "symfony/debug",
       "version": "v4.4.27",
       "source": {
@@ -9063,6 +9697,65 @@
         }
       ],
       "time": "2021-07-22T07:21:39+00:00"
+    },
+    {
+      "name": "symfony/filesystem",
+      "version": "v5.3.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/symfony/filesystem.git",
+        "reference": "343f4fe324383ca46792cae728a3b6e2f708fb32"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/symfony/filesystem/zipball/343f4fe324383ca46792cae728a3b6e2f708fb32",
+        "reference": "343f4fe324383ca46792cae728a3b6e2f708fb32",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.2.5",
+        "symfony/polyfill-ctype": "~1.8",
+        "symfony/polyfill-php80": "^1.16"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Symfony\\Component\\Filesystem\\": ""
+        },
+        "exclude-from-classmap": ["/Tests/"]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": ["MIT"],
+      "authors": [
+        {
+          "name": "Fabien Potencier",
+          "email": "fabien@symfony.com"
+        },
+        {
+          "name": "Symfony Community",
+          "homepage": "https://symfony.com/contributors"
+        }
+      ],
+      "description": "Provides basic utilities for the filesystem",
+      "homepage": "https://symfony.com",
+      "support": {
+        "source": "https://github.com/symfony/filesystem/tree/v5.3.4"
+      },
+      "funding": [
+        {
+          "url": "https://symfony.com/sponsor",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/fabpot",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2021-07-21T12:40:44+00:00"
     },
     {
       "name": "symfony/thanks",
@@ -9186,5 +9879,5 @@
   "platform-overrides": {
     "php": "7.3.20"
   },
-  "plugin-api-version": "2.0.0"
+  "plugin-api-version": "2.1.0"
 }

--- a/config/app.php
+++ b/config/app.php
@@ -180,7 +180,8 @@ return [
 
         StudentAffairsUwm\Shibboleth\ShibbolethServiceProvider::class,
         StudentAffairsUwm\Shibboleth\ShibalikeServiceProvider::class,
-        Lab404\Impersonate\ImpersonateServiceProvider::class
+        Lab404\Impersonate\ImpersonateServiceProvider::class,
+        Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class,
     ],
 
     /*

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -1,0 +1,308 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Filename & Format
+    |--------------------------------------------------------------------------
+    |
+    | The default filename
+    |
+    */
+
+    'filename'  => '_ide_helper.php',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Where to write the PhpStorm specific meta file
+    |--------------------------------------------------------------------------
+    |
+    | PhpStorm also supports the directory `.phpstorm.meta.php/` with arbitrary
+    | files in it, should you need additional files for your project; e.g.
+    | `.phpstorm.meta.php/laravel_ide_Helper.php'.
+    |
+    */
+    'meta_filename' => '.phpstorm.meta.php',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Fluent helpers
+    |--------------------------------------------------------------------------
+    |
+    | Set to true to generate commonly used Fluent methods
+    |
+    */
+
+    'include_fluent' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Factory Builders
+    |--------------------------------------------------------------------------
+    |
+    | Set to true to generate factory generators for better factory()
+    | method auto-completion.
+    |
+    | Deprecated for Laravel 8 or latest.
+    |
+    */
+
+    'include_factory_builders' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Write Model Magic methods
+    |--------------------------------------------------------------------------
+    |
+    | Set to false to disable write magic methods of model
+    |
+    */
+
+    'write_model_magic_where' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Write Model External Eloquent Builder methods
+    |--------------------------------------------------------------------------
+    |
+    | Set to false to disable write external eloquent builder methods
+    |
+    */
+
+    'write_model_external_builder_methods' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Write Model relation count properties
+    |--------------------------------------------------------------------------
+    |
+    | Set to false to disable writing of relation count properties to model DocBlocks.
+    |
+    */
+
+    'write_model_relation_count_properties' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Write Eloquent Model Mixins
+    |--------------------------------------------------------------------------
+    |
+    | This will add the necessary DocBlock mixins to the model class
+    | contained in the Laravel Framework. This helps the IDE with
+    | auto-completion.
+    |
+    | Please be aware that this setting changes a file within the /vendor directory.
+    |
+    */
+
+    'write_eloquent_model_mixins' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Helper files to include
+    |--------------------------------------------------------------------------
+    |
+    | Include helper files. By default not included, but can be toggled with the
+    | -- helpers (-H) option. Extra helper files can be included.
+    |
+    */
+
+    'include_helpers' => false,
+
+    'helper_files' => [
+        base_path() . '/vendor/laravel/framework/src/Illuminate/Support/helpers.php',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Model locations to include
+    |--------------------------------------------------------------------------
+    |
+    | Define in which directories the ide-helper:models command should look
+    | for models.
+    |
+    | glob patterns are supported to easier reach models in sub-directories,
+    | e.g. `app/Services/* /Models` (without the space)
+    |
+    */
+
+    'model_locations' => [
+        'app',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Models to ignore
+    |--------------------------------------------------------------------------
+    |
+    | Define which models should be ignored.
+    |
+    */
+
+    'ignored_models' => [
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Models hooks
+    |--------------------------------------------------------------------------
+    |
+    | Define which hook classes you want to run for models to add custom information
+    |
+    | Hooks should implement Barryvdh\LaravelIdeHelper\Contracts\ModelHookInterface.
+    |
+    */
+
+    'model_hooks' => [
+        // App\Support\IdeHelper\MyModelHook::class
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Extra classes
+    |--------------------------------------------------------------------------
+    |
+    | These implementations are not really extended, but called with magic functions
+    |
+    */
+
+    'extra' => [
+        'Eloquent' => ['Illuminate\Database\Eloquent\Builder', 'Illuminate\Database\Query\Builder'],
+        'Session' => ['Illuminate\Session\Store'],
+    ],
+
+    'magic' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Interface implementations
+    |--------------------------------------------------------------------------
+    |
+    | These interfaces will be replaced with the implementing class. Some interfaces
+    | are detected by the helpers, others can be listed below.
+    |
+    */
+
+    'interfaces' => [
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Support for custom DB types
+    |--------------------------------------------------------------------------
+    |
+    | This setting allow you to map any custom database type (that you may have
+    | created using CREATE TYPE statement or imported using database plugin
+    | / extension to a Doctrine type.
+    |
+    | Each key in this array is a name of the Doctrine2 DBAL Platform. Currently valid names are:
+    | 'postgresql', 'db2', 'drizzle', 'mysql', 'oracle', 'sqlanywhere', 'sqlite', 'mssql'
+    |
+    | This name is returned by getName() method of the specific Doctrine/DBAL/Platforms/AbstractPlatform descendant
+    |
+    | The value of the array is an array of type mappings. Key is the name of the custom type,
+    | (for example, "jsonb" from Postgres 9.4) and the value is the name of the corresponding Doctrine2 type (in
+    | our case it is 'json_array'. Doctrine types are listed here:
+    | http://doctrine-dbal.readthedocs.org/en/latest/reference/types.html
+    |
+    | So to support jsonb in your models when working with Postgres, just add the following entry to the array below:
+    |
+    | "postgresql" => array(
+    |       "jsonb" => "json_array",
+    |  ),
+    |
+    */
+    'custom_db_types' => [
+
+    ],
+
+    /*
+     |--------------------------------------------------------------------------
+     | Support for camel cased models
+     |--------------------------------------------------------------------------
+     |
+     | There are some Laravel packages (such as Eloquence) that allow for accessing
+     | Eloquent model properties via camel case, instead of snake case.
+     |
+     | Enabling this option will support these packages by saving all model
+     | properties as camel case, instead of snake case.
+     |
+     | For example, normally you would see this:
+     |
+     |  * @property \Illuminate\Support\Carbon $created_at
+     |  * @property \Illuminate\Support\Carbon $updated_at
+     |
+     | With this enabled, the properties will be this:
+     |
+     |  * @property \Illuminate\Support\Carbon $createdAt
+     |  * @property \Illuminate\Support\Carbon $updatedAt
+     |
+     | Note, it is currently an all-or-nothing option.
+     |
+     */
+    'model_camel_case_properties' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Property Casts
+    |--------------------------------------------------------------------------
+    |
+    | Cast the given "real type" to the given "type".
+    |
+    */
+    'type_overrides' => [
+        'integer' => 'int',
+        'boolean' => 'bool',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Include DocBlocks from classes
+    |--------------------------------------------------------------------------
+    |
+    | Include DocBlocks from classes to allow additional code inspection for
+    | magic methods and properties.
+    |
+    */
+    'include_class_docblocks' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Force FQN usage
+    |--------------------------------------------------------------------------
+    |
+    | Use the fully qualified (class) name in docBlock,
+    | event if class exists in a given file
+    | or there is an import (use className) of a given class
+    |
+    */
+    'force_fqn' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Additional relation types
+    |--------------------------------------------------------------------------
+    |
+    | Sometimes it's needed to create custom relation types. The key of the array
+    | is the Relationship Method name. The value of the array is the canonical class
+    | name of the Relationship, e.g. `'relationName' => RelationShipClass::class`.
+    |
+    */
+    'additional_relation_types' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Run artisan commands after migrations to generate model helpers
+    |--------------------------------------------------------------------------
+    |
+    | The specified commands should run after migrations are finished running.
+    |
+    */
+    'post_migrate' => [
+        // 'ide-helper:models --nowrite',
+    ],
+
+];


### PR DESCRIPTION
Adds [Laravel IDE Helper](https://github.com/barryvdh/laravel-ide-helper) as php dev dependency.

Makes intelephense a bit smarter so that [Unidentified symbol 'Route'](https://github.com/bmewburn/vscode-intelephense/issues/780) goes away in vs code.
