### PR TITLE
Add a frame and message when presenter is within participant view.

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+| Permission Number Constants
+| ---------------------------
+| Permissions numbers are used to authorize a user's
+| action in ChimeIn.
+*/
+return [
+  'participant' => 100,
+  'presenter' => 300,
+];

--- a/cypress/support/routes.json
+++ b/cypress/support/routes.json
@@ -219,6 +219,13 @@
   "ltisettings.update": {
     "name": "ltisettings.update",
     "domain": null,
+    "action": "App\\Http\\Controllers\\LTIHandler@saveLTISettings",
+    "uri": "lti/saveLTISettings/{chime}",
+    "method": ["PUT"]
+  },
+  "ltisettings13.update": {
+    "name": "ltisettings13.update",
+    "domain": null,
     "action": "App\\Http\\Controllers\\LTI13Handler@saveLTISettings",
     "uri": "lti13/saveLTISettings/{chime}",
     "method": ["PUT"]

--- a/database/factories/ChimeFactory.php
+++ b/database/factories/ChimeFactory.php
@@ -7,6 +7,6 @@ $factory->define(App\Chime::class, function (Faker $faker) {
     $temp = new \App\Chime;
     return [
         'access_code' => $temp->getUniqueCode(),
-        'name' => $faker->name,
+        'name' => $faker->words(3, true),
     ];
 });

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1,5 +1,6 @@
 import Vue from "vue";
 import VueAnnouncer from "vue-announcer";
+import "bootstrap";
 import registerAxios from "./common/axios.js";
 import registerEcho from "./common/echo.js";
 import registerSocketIOClient from "./common/socketioClient.js";

--- a/resources/assets/js/components/FreeResponse/FreeResponseInputs.vue
+++ b/resources/assets/js/components/FreeResponse/FreeResponseInputs.vue
@@ -49,6 +49,8 @@
 </template>
 
 <script>
+import get from "lodash/get";
+
 export default {
   props: ["question", "response", "disabled"],
   data() {
@@ -65,16 +67,7 @@ export default {
     },
   },
   mounted() {
-    const hasOwn = Object.prototype.hasOwnProperty.call;
-    const response = this.response;
-
-    if (
-      response &&
-      hasOwn(response, "response_info") &&
-      hasOwn(response.response_info, "text")
-    ) {
-      this.response_text = response.response_info.text;
-    }
+    this.response_text = get(this, "response.response_info.text", "");
   },
   methods: {
     record_response: function () {

--- a/resources/assets/js/components/ImageHeatmapResponse/ImageHeatmapResponseInputs.vue
+++ b/resources/assets/js/components/ImageHeatmapResponse/ImageHeatmapResponseInputs.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="col-sm-12">
       <div
-        v-if="image_coordinates"
+        v-if="image_coordinates && targetImageLoaded"
         class="clickPointer"
         :style="{
           top: image_coordinates.coordinate_y + 'px',
@@ -15,7 +15,7 @@
         class="img-fluid max-height-image"
         :src="'/storage/' + question.question_info.question_responses.image"
         @click="triggerResponse"
-        @load="updateScaledCoordinates"
+        @load="handleTargetImageLoaded"
       />
     </div>
     <div class="col-sm-12">
@@ -53,10 +53,13 @@
 </style>
 
 <script>
+import get from "lodash/get";
+
 export default {
   props: ["question", "response", "disabled"],
   data() {
     return {
+      targetImageLoaded: false,
       image_coordinates: null,
       create_new_response: false,
     };
@@ -72,20 +75,22 @@ export default {
   destroyed() {
     window.removeEventListener("resize", this.updateScaledCoordinates);
   },
-  mounted() {
-    this.updateScaledCoordinates();
-  },
+
   methods: {
-    updateScaledCoordinates: function () {
-      if (
-        !this.response ||
-        !this.response.response_info ||
-        !this.response.response_info.image_coordinates
-      ) {
+    handleTargetImageLoaded() {
+      this.targetImageLoaded = true;
+      this.updateScaledCoordinates();
+    },
+    updateScaledCoordinates() {
+      const targetImage = this.$refs["targetImage"];
+      const imageCoordinates = get(
+        this,
+        "response.response_info.image_coordinates"
+      );
+
+      if (!imageCoordinates || !targetImage) {
         return;
       }
-
-      var targetImage = this.$refs["targetImage"];
 
       var cw = targetImage.clientWidth;
       var ch = targetImage.clientHeight;
@@ -129,6 +134,15 @@ export default {
       this.$emit("recordresponse", response, this.create_new_response);
       this.create_new_response = false;
     },
+    // record_response: function() {
+    //     const response = {
+    //         question_type: 'heatmap_response',
+    //         image_coordinates: this.image_coordinates
+    //     }
+
+    //     this.$emit('recordresponse', response, false);
+
+    // }
   },
 };
 </script>

--- a/resources/assets/js/components/ImageHeatmapResponse/ImageHeatmapResponseInputs.vue
+++ b/resources/assets/js/components/ImageHeatmapResponse/ImageHeatmapResponseInputs.vue
@@ -73,15 +73,7 @@ export default {
     window.removeEventListener("resize", this.updateScaledCoordinates);
   },
   mounted() {
-    const hasOwn = Object.prototype.hasOwnProperty.call;
-    const response = this.response;
-    if (
-      response &&
-      hasOwn(response, "response_info") &&
-      hasOwn(response.response_info, "image_coordinates")
-    ) {
-      this.updateScaledCoordinates();
-    }
+    this.updateScaledCoordinates();
   },
   methods: {
     updateScaledCoordinates: function () {
@@ -137,15 +129,6 @@ export default {
       this.$emit("recordresponse", response, this.create_new_response);
       this.create_new_response = false;
     },
-    // record_response: function() {
-    //     const response = {
-    //         question_type: 'heatmap_response',
-    //         image_coordinates: this.image_coordinates
-    //     }
-
-    //     this.$emit('recordresponse', response, false);
-
-    // }
   },
 };
 </script>

--- a/resources/assets/js/components/MultipleChoice/MultipleChoiceInputs.vue
+++ b/resources/assets/js/components/MultipleChoice/MultipleChoiceInputs.vue
@@ -61,7 +61,7 @@ export default {
     },
   },
   mounted() {
-    this.selected = get(this, "response.response_info.choice", []);
+    this.selected = get(this, "response.response_info.choice", null);
   },
 };
 </script>

--- a/resources/assets/js/components/MultipleChoice/MultipleChoiceInputs.vue
+++ b/resources/assets/js/components/MultipleChoice/MultipleChoiceInputs.vue
@@ -21,6 +21,7 @@
 </template>
 
 <script>
+import get from "lodash/get";
 export default {
   props: ["question", "response", "disabled"],
   data() {
@@ -60,15 +61,7 @@ export default {
     },
   },
   mounted() {
-    const hasOwn = Object.prototype.hasOwnProperty.call;
-    const response = this.response;
-    if (
-      response &&
-      hasOwn(response, "response_info") &&
-      hasOwn(response.response_info, "choice")
-    ) {
-      this.selected = this.response.response_info.choice;
-    }
+    this.selected = get(this, "response.response_info.choice", []);
   },
 };
 </script>

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -71,7 +71,7 @@
               class="btn btn-sm btn-outline-secondary align-items-center d-flex"
             >
               Participant View
-              <i class="material-icons">search</i>
+              <i class="material-icons">preview</i>
             </router-link>
             <router-link
               :to="{

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -31,7 +31,7 @@
             aria-label="Folder Controls"
           >
             <button
-              class="btn btn-sm btn-outline-info align-items-center d-flex"
+              class="btn btn-sm btn-outline-secondary align-items-center d-flex"
               @click="show_edit_folder = !show_edit_folder"
             >
               Folder Settings <i class="material-icons pointer">edit</i>
@@ -40,29 +40,35 @@
             <button
               dusk="new-question-button"
               data-cy="new-question-button"
-              class="btn btn-sm btn-outline-info align-items-center d-flex"
+              class="btn btn-sm btn-outline-secondary align-items-center d-flex"
               @click="showModal = true"
             >
               New Question <i class="material-icons pointer">add</i>
             </button>
             <button
               dusk="open-all-button"
-              class="btn btn-sm btn-outline-info align-items-center d-flex"
+              class="btn btn-sm btn-outline-secondary align-items-center d-flex"
               @click="openAll"
             >
               Open All <i class="material-icons pointer">visibility</i>
             </button>
             <button
               dusk="close-all-button"
-              class="btn btn-sm btn-outline-info align-items-center d-flex"
+              class="btn btn-sm btn-outline-secondary align-items-center d-flex"
               @click="closeAll"
             >
               Close All <i class="material-icons pointer">visibility_off</i>
             </button>
             <router-link
-              :to="{ name: 'chimeStudent', params: { chimeId: chimeId } }"
+              :to="{
+                name: 'chimeStudent',
+                params: { chimeId: chimeId },
+                query: {
+                  viewMode: 'participant',
+                },
+              }"
               tag="button"
-              class="btn btn-sm btn-outline-info align-items-center d-flex"
+              class="btn btn-sm btn-outline-secondary align-items-center d-flex"
             >
               Participant View
               <i class="material-icons">search</i>
@@ -73,7 +79,7 @@
                 params: { chimeId: chimeId, folderId: folderId },
               }"
               tag="button"
-              class="btn btn-sm btn-outline-info align-items-center d-flex"
+              class="btn btn-sm btn-outline-secondary align-items-center d-flex"
             >
               Present
               <i class="material-icons">play_arrow</i>

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -65,6 +65,7 @@
                 params: { chimeId: chimeId },
                 query: {
                   viewMode: 'participant',
+                  callbackUrl: $route.path,
                 },
               }"
               tag="button"

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -1,5 +1,9 @@
 <template>
-  <div>
+  <div
+    class="participant-page"
+    :class="{ 'participant-page--in-participant-viewmode': inParticipantView }"
+  >
+    <ViewModeNotice v-if="inParticipantView" />
     <NavBar title="Home" :user="user" :link="'/'" />
     <ErrorDialog />
     <div v-if="error" class="alert alert-warning" role="alert">
@@ -79,12 +83,18 @@
 .nav-item {
   width: 50%;
 }
+
+/* .participant-page--in-participant-viewmode {
+  border: 0.5rem solid #333;
+} */
 </style>
 <script>
+import get from "lodash/get";
 import ErrorDialog from "../../components/ErrorDialog.vue";
 import NavBar from "../../components/NavBar.vue";
 import ParticipantPrompt from "./ParticipantPrompt.vue";
 import Response from "./ParticipantResponse.vue";
+import ViewModeNotice from "./ParticipantPageViewModeNotice.vue";
 
 export default {
   components: {
@@ -92,6 +102,7 @@ export default {
     NavBar,
     ParticipantPrompt,
     Response,
+    ViewModeNotice,
   },
   props: ["user", "chimeId", "folderId"],
   data() {
@@ -104,6 +115,12 @@ export default {
     };
   },
   computed: {
+    inParticipantView() {
+      const viewMode = get(this, "$route.query.viewMode", null);
+      if (!viewMode) return false;
+
+      return viewMode.toLowerCase() === "participant";
+    },
     filteredSession: function () {
       if (this.folderId) {
         return this.sessions.filter(

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -91,7 +91,7 @@ import ErrorDialog from "../../components/ErrorDialog.vue";
 import NavBar from "../../components/NavBar.vue";
 import ParticipantPrompt from "./ParticipantPrompt.vue";
 import Response from "./ParticipantResponse.vue";
-import ViewModeNotice from "./ParticipantPageViewModeNotice.vue";
+import ViewModeNotice from "./ViewModeNotice.vue";
 
 export default {
   components: {

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -1,9 +1,10 @@
 <template>
-  <div
-    class="participant-page"
-    :class="{ 'participant-page--in-participant-viewmode': inParticipantView }"
-  >
-    <ViewModeNotice v-if="inParticipantView" />
+  <div class="participant-page">
+    <ViewModeNotice
+      v-if="inParticipantView"
+      :canvasUrl="canvasCourseUrl"
+      :joinUrl="joinUrl"
+    />
     <NavBar title="Home" :user="user" :link="'/'" />
     <ErrorDialog />
     <div v-if="error" class="alert alert-warning" role="alert">
@@ -83,10 +84,6 @@
 .nav-item {
   width: 50%;
 }
-
-/* .participant-page--in-participant-viewmode {
-  border: 0.5rem solid #333;
-} */
 </style>
 <script>
 import get from "lodash/get";
@@ -115,6 +112,15 @@ export default {
     };
   },
   computed: {
+    canvasCourseUrl() {
+      const url = this.chime.lti_return_url;
+      if (!url) return null;
+      const found = url.match(/^(?<courseUrl>http.*\/courses\/\d+).*/);
+      return found.groups.courseUrl || null;
+    },
+    joinUrl() {
+      return `${window.location.origin}/join/${this.chime.access_code}`;
+    },
     inParticipantView() {
       const viewMode = get(this, "$route.query.viewMode", null);
       if (!viewMode) return false;

--- a/resources/assets/js/views/ParticipantPage/ParticipantPageViewModeNotice.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPageViewModeNotice.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="view-mode">
+    <div>
+      <h2 class="view-mode__heading">Participant View</h2>
+      <p>This is a preview of what your Chime participants will see.</p>
+    </div>
+    <div>
+      <h2 class="view-mode__heading">Share</h2>
+      <p>
+        <a href="canvasUrl || joinUrl">{{ canvasUrl || joinUrl }}</a>
+      </p>
+    </div>
+    <div>
+      <button class="btn btn-outline-secondary" @click="$router.go(-1)">
+        Leave Participant View
+      </button>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    canvasChimeUrl: String,
+    joinUrl: String,
+  },
+};
+</script>
+<style scoped>
+.view-mode {
+  background: hsla(0, 0%, 0%, 0.75);
+  backdrop-filter: blur(1rem);
+  color: #aaa;
+  padding: 1rem;
+  font-size: 0.8rem;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100vw;
+  z-index: 100;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+.view-mode__heading {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  font-weight: bold;
+  letter-spacing: 1px;
+}
+.view-mode p {
+  margin: 0;
+}
+.view-mode button {
+  font-size: 0.8rem;
+  border-color: #aaa;
+  color: #aaa;
+}
+.view-mode > div:last-child {
+  padding-right: 1rem;
+  align-self: center;
+  justify-self: flex-end;
+}
+</style>

--- a/resources/assets/js/views/ParticipantPage/ParticipantPageViewModeNotice.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPageViewModeNotice.vue
@@ -1,16 +1,19 @@
 <template>
   <div class="view-mode">
-    <div>
-      <h2 class="view-mode__heading">Participant View</h2>
-      <p>This is a preview of what your Chime participants will see.</p>
+    <div class="column column--participant-view">
+      <i class="material-icons">preview</i>
+      <div>
+        <h2 class="view-mode__heading">Participant View</h2>
+        <p>This is a preview of what your Chime participants will see.</p>
+      </div>
     </div>
-    <div>
-      <h2 class="view-mode__heading">Share</h2>
+    <div class="column column--share">
+      <h3 class="view-mode__subheading">Link to Join</h3>
       <p>
-        <a href="canvasUrl || joinUrl">{{ canvasUrl || joinUrl }}</a>
+        <a :href="canvasUrl || joinUrl">{{ canvasUrl || joinUrl }}</a>
       </p>
     </div>
-    <div>
+    <div class="column column--leave">
       <button class="btn btn-outline-secondary" @click="$router.go(-1)">
         Leave Participant View
       </button>
@@ -20,44 +23,89 @@
 <script>
 export default {
   props: {
-    canvasChimeUrl: String,
-    joinUrl: String,
+    canvasUrl: {
+      type: String,
+      default: "",
+    },
+    joinUrl: {
+      type: String,
+      default: "",
+    },
+  },
+  mounted() {
+    document.body.classList.add("page--viewmode-participant");
+  },
+  destroyed() {
+    document.body.classList.remove("page--viewmode-participant");
   },
 };
 </script>
+<style>
+:root {
+  --color-viewmode-bg: #333;
+  --color-viewmode-heading: #ccc;
+  --color-viewmode-text: #777;
+  /* --color-viewmode-link: var(--gold); */
+  --color-viewmode-link: hsla(45deg, 90%, 65%, 0.9);
+}
+.page--viewmode-participant {
+  border: 1rem solid var(--color-viewmode-bg);
+  padding-bottom: 4rem;
+}
+</style>
+
 <style scoped>
 .view-mode {
-  background: hsla(0, 0%, 0%, 0.75);
-  backdrop-filter: blur(1rem);
-  color: #aaa;
-  padding: 1rem;
+  background: var(--color-viewmode-bg);
+  color: #777;
   font-size: 0.8rem;
   position: fixed;
   bottom: 0;
   left: 0;
-  width: 100vw;
-  z-index: 100;
+  z-index: 10;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1rem;
+  padding: 1.5rem 1rem 1rem;
 }
-.view-mode__heading {
+.view-mode a {
+  color: var(--color-viewmode-link);
+}
+
+.view-mode__heading,
+.view-mode__subheading {
+  color: var(--color-viewmode-heading);
   font-size: 0.8rem;
   text-transform: uppercase;
   font-weight: bold;
   letter-spacing: 1px;
 }
+
+.view-mode__subheading {
+  color: var(--color-viewmode-text);
+}
+
 .view-mode p {
   margin: 0;
 }
 .view-mode button {
   font-size: 0.8rem;
-  border-color: #aaa;
-  color: #aaa;
+  border-color: var(--color-viewmode-link);
+  color: var(--color-viewmode-link);
 }
 .view-mode > div:last-child {
-  padding-right: 1rem;
   align-self: center;
   justify-self: flex-end;
+}
+
+.column:first-child {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+i {
+  display: block;
+  margin-right: 1rem;
+  font-size: 2rem;
 }
 </style>

--- a/resources/assets/js/views/ParticipantPage/ParticipantPageViewModeNotice.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPageViewModeNotice.vue
@@ -1,23 +1,19 @@
 <template>
-  <div class="view-mode">
-    <div class="column column--participant-view">
-      <i class="material-icons">preview</i>
-      <div>
+  <div class="view-mode grid">
+    <div>
+      <header class="view-mode__header">
+        <i class="material-icons">preview</i>
         <h2 class="view-mode__heading">Participant View</h2>
-        <p>This is a preview of what your Chime participants will see.</p>
-      </div>
-    </div>
-    <div class="column column--share">
-      <h3 class="view-mode__subheading">Link to Join</h3>
+      </header>
+      <p>This is a preview of what your Chime participants will see.</p>
       <p>
         <a :href="canvasUrl || joinUrl">{{ canvasUrl || joinUrl }}</a>
       </p>
     </div>
-    <div class="column column--leave">
-      <button class="btn btn-outline-secondary" @click="$router.go(-1)">
-        Leave Participant View
-      </button>
-    </div>
+
+    <button @click="leaveParticipantView" class="btn btn-outline-secondary">
+      Leave Participant View
+    </button>
   </div>
 </template>
 <script>
@@ -30,6 +26,16 @@ export default {
     joinUrl: {
       type: String,
       default: "",
+    },
+  },
+  data() {
+    return {
+      historyLengthOnMount: 0,
+    };
+  },
+  methods: {
+    leaveParticipantView() {
+      window.history.length > 1 ? this.$router.go(-1) : this.$router.push("/");
     },
   },
   mounted() {
@@ -45,7 +51,6 @@ export default {
   --color-viewmode-bg: #333;
   --color-viewmode-heading: #ccc;
   --color-viewmode-text: #777;
-  /* --color-viewmode-link: var(--gold); */
   --color-viewmode-link: hsla(45deg, 90%, 65%, 0.9);
 }
 .page--viewmode-participant {
@@ -57,55 +62,67 @@ export default {
 <style scoped>
 .view-mode {
   background: var(--color-viewmode-bg);
-  color: #777;
+  color: var(--color-viewmode-text);
   font-size: 0.8rem;
   position: fixed;
   bottom: 0;
   left: 0;
   z-index: 10;
+  padding: 1rem;
+}
+
+.view-mode__header {
+  display: flex;
+  align-items: center;
+  color: var(--color-viewmode-heading);
+  margin-bottom: 0.5rem;
+}
+
+.view-mode__header i {
+  margin-right: 0.5rem;
+}
+
+.view-mode__heading {
+  color: var(--color-viewmode-heading);
+  font-size: 1rem;
+  text-transform: uppercase;
+  font-weight: bold;
+  letter-spacing: 1px;
+  margin: 0;
+}
+
+.view-mode__subheading {
+  color: var(--color-viewmode-heading);
+  font-size: 1rem;
+  text-transform: uppercase;
+  font-weight: bold;
+  letter-spacing: 1px;
+  margin: 0;
+}
+
+.grid {
+  width: 100%;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: 2fr 1fr;
   gap: 1rem;
-  padding: 1.5rem 1rem 1rem;
 }
 .view-mode a {
   color: var(--color-viewmode-link);
 }
 
-.view-mode__heading,
-.view-mode__subheading {
-  color: var(--color-viewmode-heading);
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  font-weight: bold;
-  letter-spacing: 1px;
-}
-
-.view-mode__subheading {
-  color: var(--color-viewmode-text);
-}
-
 .view-mode p {
-  margin: 0;
+  margin: 0.5em 0;
 }
 .view-mode button {
   font-size: 0.8rem;
   border-color: var(--color-viewmode-link);
   color: var(--color-viewmode-link);
-}
-.view-mode > div:last-child {
   align-self: center;
   justify-self: flex-end;
 }
-
-.column:first-child {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-i {
-  display: block;
-  margin-right: 1rem;
-  font-size: 2rem;
+.view-mode button:hover,
+.view-mode button:focus {
+  background: var(--color-viewmode-link);
+  color: var(--color-viewmode-bg);
 }
 </style>

--- a/resources/assets/js/views/ParticipantPage/ViewModeNotice.vue
+++ b/resources/assets/js/views/ParticipantPage/ViewModeNotice.vue
@@ -10,10 +10,11 @@
         <a :href="canvasUrl || joinUrl">{{ canvasUrl || joinUrl }}</a>
       </p>
     </div>
-
-    <button @click="leaveParticipantView" class="btn btn-outline-secondary">
-      Leave Participant View
-    </button>
+    <div>
+      <router-link :to="callbackUrl" class="btn btn-outline-secondary">
+        Leave Participant View
+      </router-link>
+    </div>
   </div>
 </template>
 <script>
@@ -28,10 +29,10 @@ export default {
       default: "",
     },
   },
-  data() {
-    return {
-      historyLengthOnMount: 0,
-    };
+  computed: {
+    callbackUrl() {
+      return this.$route.query.callbackUrl || "/";
+    },
   },
   methods: {
     leaveParticipantView() {
@@ -113,15 +114,19 @@ export default {
 .view-mode p {
   margin: 0.5em 0;
 }
-.view-mode button {
-  font-size: 0.8rem;
+
+.view-mode > div:last-child {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+.view-mode .btn {
+  font-size: 1rem;
   border-color: var(--color-viewmode-link);
   color: var(--color-viewmode-link);
-  align-self: center;
-  justify-self: flex-end;
 }
-.view-mode button:hover,
-.view-mode button:focus {
+.view-mode .btn:hover,
+.view-mode .btn:focus {
   background: var(--color-viewmode-link);
   color: var(--color-viewmode-bg);
 }

--- a/resources/assets/js/views/QuestionForm/QuestionForm.vue
+++ b/resources/assets/js/views/QuestionForm/QuestionForm.vue
@@ -299,8 +299,7 @@ export default {
         url = url + "/question/" + this.question.id;
         axios
           .put(url, responseBlock)
-          .then((res) => {
-            console.log(res);
+          .then(() => {
             this.$emit("edited");
           })
           .catch((err) => {

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -55,7 +55,7 @@ html {
 }
 
 body {
-  height: 100%;
+  min-height: 100%;
   font-family: "Open Sans", sans-serif;
   color: var(--black);
   line-height: 1.4;


### PR DESCRIPTION
Related to #78:

- Updates ParticipantView page to make it clearer that they're in "Participant View" by adding a wrapper to the view.
- The share URL is included in the bottom. If the chime has an LTI link, it will display a link to the Canvas course `https://canvas.umn.edu/courses/123456` rather than the join link.
- Adds a "Leave Participant View" button which lets users return to previous URL.

Current ParticipantView looks like this:
<img width="500" alt="Screen Shot 2021-11-16 at 9 53 17 PM" src="https://user-images.githubusercontent.com/980170/142136024-e2745613-a40d-4464-8219-e18c1a223a13.png">

Also fixes a few regressions after recent refactor:
- imports bootstrap's js, fixing an issue where clicking on a closed tab wouldn't do anything.
- Within an ImageHeatmap question, added a check to make sure target image is loaded before invoking `updateScaledCoordinates`, which resolves an error in the js console.
