### PR TITLE
Return of the animations 🍿

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ yarn-error.log
 *.DS_Store
 .phpintel
 docs/.vuepress/dist
-cypress/**/__diff_output__
+/cypress/**/routes.json
+/cypress/**/__diff_output__

--- a/cypress/integration/ui/question.test.js
+++ b/cypress/integration/ui/question.test.js
@@ -425,6 +425,9 @@ describe("question", () => {
           // wait for equations to render
           cy.get(".katex-html");
 
+          // wait for animation to complete
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
+          cy.wait(1500);
           cy.get("#app").matchImageSnapshot("results-of-equation-choices");
         });
     });
@@ -469,9 +472,9 @@ describe("question", () => {
           cy.get("[data-cy=present-question-button]").click();
           cy.get("[data-cy=show-results-button]").click();
 
-          // wait for rendering
+          // wait for rendering and animation to complete
           // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(1000);
+          cy.wait(1500);
           cy.get("#app").matchImageSnapshot(
             `mult-choice-stats-with-long-labels`
           );
@@ -743,6 +746,10 @@ describe("question", () => {
           cy.visit(`/chime/${testChime.id}/folder/${testFolder.id}`);
           cy.get("[data-cy=present-question-button]").click();
           cy.get("[data-cy=show-results-button]").click();
+
+          // wait for animation to complete
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
+          cy.wait(1500);
 
           // expect the labels to be displayed
           cy.get("[data-cy=chart-container]")

--- a/resources/assets/js/helpers/insertHtmlLabelsIntoGchart.js
+++ b/resources/assets/js/helpers/insertHtmlLabelsIntoGchart.js
@@ -1,0 +1,43 @@
+/**
+ * Replaces gchart text labels with given html labels array
+ * @param {*} gChartEl - reference to google chart to update
+ * @param {*} htmlLabelsArray - array of html labels like `<p>Label 1</p>`
+ */
+export default function insertHtmlLabelsIntoGchart(gChartEl, htmlLabelsArray) {
+  // get labels that contain html paragraphs
+  const currentTextLabels = [...gChartEl.querySelectorAll("text")].filter(
+    (el) => /<p>/.test(el.textContent)
+  );
+
+  // we'll use the chart bars to help with positioning
+  // getting bars by stroke color... a bit hacky, but it works
+  const bars = [...gChartEl.querySelectorAll('[stroke="#36a2eb"]')];
+
+  // replace each text node with a `<foreignObject>` element
+  // containing the HTML
+  currentTextLabels.forEach((label, index) => {
+    const bar = bars[index];
+
+    // if no bar, don't bother with the label
+    if (!bar) {
+      label.parentNode.innerHTML = "";
+      return;
+    }
+
+    // use bar attributes for placing label
+    const x = bar.getAttribute("x");
+    const width = bar.getAttribute("width");
+    const y =
+      Number.parseFloat(bar.getAttribute("y")) +
+      Number.parseFloat(bar.getAttribute("height")) +
+      16;
+
+    // set some height with overflow visible to make sure that
+    // foreignObject isn't clipped
+    label.parentNode.innerHTML = `
+                <foreignObject width="${width}" height="1" x=${x} y=${y} style="overflow: visible;">
+                  ${htmlLabelsArray[index]}
+                </foreignObject>
+              `;
+  });
+}

--- a/resources/assets/js/views/PresentPage/MultipleChoiceStatistics.vue
+++ b/resources/assets/js/views/PresentPage/MultipleChoiceStatistics.vue
@@ -31,10 +31,6 @@
 import { GChart } from "vue-google-charts";
 import isObject from "lodash/isObject";
 import insertHtmlLabelsIntoGchart from "../../helpers/insertHtmlLabelsIntoGchart";
-import unescape from "lodash/unescape";
-
-const htmlToPlainText = (htmlString) =>
-  unescape(htmlString.replace(/<[^>]*>/g, ""));
 
 const ANIMATION_DURATION = 1000;
 
@@ -48,8 +44,7 @@ export default {
       visible_responses: [],
       response_search: "",
       chartEvents: {
-        ready: () =>
-          this.shouldRenderLabelsAsHtml && this.handleHtmlChartLabels(),
+        ready: () => this.handleHtmlChartLabels(),
       },
       options: {
         height: "100%",
@@ -104,16 +99,10 @@ export default {
         position: "relative",
       };
     },
-    shouldRenderLabelsAsHtml() {
-      return this.question.question_info.question_responses.some((choice) =>
-        /<math .*>/.test(choice.text)
-      );
-    },
     chartData: function () {
       var questionArray = this.question.question_info.question_responses.map(
         (q) => {
           const choiceHtml = isObject(q) ? q.text : q;
-          const choicePlainText = htmlToPlainText(choiceHtml);
           const totalResponsesForQuestion = this.responses.length;
 
           // number of users making this choice
@@ -124,7 +113,7 @@ export default {
           ).length;
 
           return [
-            this.shouldRenderLabelsAsHtml ? choiceHtml : choicePlainText,
+            choiceHtml,
             totalResponsesForChoice / totalResponsesForQuestion,
             "color: rgb(54, 162, 235); opacity: 0.4; stroke-opacity: 0.9; stroke-width: 2",
             "Number of Responses:  " +

--- a/resources/assets/js/views/PresentPage/MultipleChoiceStatistics.vue
+++ b/resources/assets/js/views/PresentPage/MultipleChoiceStatistics.vue
@@ -106,7 +106,7 @@ export default {
     },
     shouldRenderLabelsAsHtml() {
       return this.question.question_info.question_responses.some((choice) =>
-        /math .*/.test(choice.text)
+        /<math .*>/.test(choice.text)
       );
     },
     chartData: function () {

--- a/resources/assets/js/views/PresentPage/MultipleChoiceStatistics.vue
+++ b/resources/assets/js/views/PresentPage/MultipleChoiceStatistics.vue
@@ -62,7 +62,6 @@ export default {
             }
 
             const elapsed = timestamp - start;
-            console.log("updating labels", elapsed);
 
             // stop looping a bit after animation duration completes
             if (elapsed < ANIMATION_DURATION * 1.25) {

--- a/resources/assets/js/views/PresentPage/SliderStatistics.vue
+++ b/resources/assets/js/views/PresentPage/SliderStatistics.vue
@@ -34,6 +34,11 @@ export default {
       response_search: "",
       options: {
         height: "100%",
+        animation: {
+          duration: 1000,
+          easing: "out",
+          startup: true,
+        },
         legend: {
           position: "none",
         },


### PR DESCRIPTION
Restores Google Chart animations on Multiple Choice Stats and Slider Stats pages.

- Adds `cy.wait` to tests to wait for animations to complete.
- Animations overwrite custom HTML `<foreignObject>` labels when they run on MultipleChoice stats. These labels are needed to render equations. I'm using `requestAnimationFrame()` to rerender labels with each step of the animation.

Closes #103.