### PR TITLE
disable save button on QuestionForm if question textbox is empty

### DIFF
--- a/resources/assets/js/views/QuestionForm/QuestionForm.vue
+++ b/resources/assets/js/views/QuestionForm/QuestionForm.vue
@@ -89,7 +89,13 @@
       </div>
       <div class="">
         <button class="btn btn-secondary" @click="close">Cancel</button>
-        <button class="btn btn-primary" @click="savePost">Save</button>
+        <button
+          class="btn btn-primary"
+          @click="savePost"
+          :disabled="!question_text.length"
+        >
+          Save
+        </button>
       </div>
     </div>
   </Modal>


### PR DESCRIPTION
Nothing fancy. Just disables save button until there's some `question_text` to prevent empty question submission and 500 error message.

Closes #114 