### PR TITLE
Hide next/prev buttons if only 1 question

### DIFF
--- a/resources/assets/js/views/PresentPage/PresentQuestion.vue
+++ b/resources/assets/js/views/PresentPage/PresentQuestion.vue
@@ -59,6 +59,7 @@
             <span v-else> View Results </span>
           </button>
           <button
+            v-if="folder.questions.length > 1"
             class="btn btn-outline-primary align-items-center d-flex"
             @click="$emit('nextQuestion')"
           >
@@ -66,6 +67,7 @@
             Next Question
           </button>
           <button
+            v-if="folder.questions.length > 1"
             class="btn btn-outline-primary align-items-center d-flex"
             @click="$emit('previousQuestion')"
           >


### PR DESCRIPTION
Fixes #113.

Went back and forth on hiding vs disabling. Landed on hiding, but let me know if you have a preference.