### PR TITLE
Add comment and inline tooltip directive

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1,11 +1,11 @@
 import Vue from "vue";
 import VueAnnouncer from "vue-announcer";
+import $ from "jquery";
 import "bootstrap";
 import registerAxios from "./common/axios.js";
 import registerEcho from "./common/echo.js";
 import registerSocketIOClient from "./common/socketioClient.js";
 import registerDevTools from "./common/devtools.js";
-import tooltipDirective from "./common/tooltip.directive.js";
 import pluralizeFilter from "./common/pluralize.filter.js";
 import router from "./router.js";
 import store from "./store.js";
@@ -18,7 +18,15 @@ registerDevTools();
 Vue.use(VueAnnouncer);
 
 Vue.filter("pluralize", pluralizeFilter);
-Vue.directive("tooltip", tooltipDirective);
+
+// $.tooltip requires jquery and bootstrap
+Vue.directive("tooltip", (el, binding) =>
+  $(el).tooltip({
+    title: binding.value,
+    placement: binding.arg,
+    trigger: "hover",
+  })
+);
 
 import ltilaunch from "./components/lti/ltiLaunch.vue";
 Vue.component("lti-launch", ltilaunch);

--- a/resources/assets/js/common/tooltip.directive.js
+++ b/resources/assets/js/common/tooltip.directive.js
@@ -1,9 +1,0 @@
-import $ from "jquery";
-
-export default function (el, binding) {
-  $(el).tooltip({
-    title: binding.value,
-    placement: binding.arg,
-    trigger: "hover",
-  });
-}


### PR DESCRIPTION
Issue is already fixed in development when we moved away from global jQuery. This just adds a comment about reqs of $.tooltip and inlines directive just in case we refactor or remove jQuery or bootstrap later.

## Details

Issue #66 was a tricky one to reproduce.

The error:
```
TypeError: $(...).tooltip is not a function
```
would only occasionally occur on the FreeResponseStatistics page. It turns out that the error can be reproduced by viewing `FreeResponseStatistics` page AFTER  viewing `ImageResponseStatistics` page. 

The problem is that `ImageResponseStatistics` is using a plugin `vue-simple-lightbox`, which – when mounted – reloads jQuery and clobbers `$.tooltip` added by bootstrap.

Here's the offending line in the lightbox component:

```
window.$ = window.jQuery = require('jquery');
```

The issue no longer is reproduceable on `development,` probably because we move to direct import of jquery for the directive, rather than using window.$.
