### PR TITLE
Remove chime drag handle

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,7 +6,7 @@ yarn run pretty-quick:staged
 
 # ESlint staged files
 # src: https://gist.github.com/dahjelle/8ddedf0aebd488208a9a7c829f19b9e8
-for file in $(git diff --cached --name-only | grep -E '\.(js|jsx)$')
+for file in $(git diff --cached --name-only | grep -E '\.(js|jsx|vue)$')
 do
   git show ":$file" | node_modules/.bin/eslint --stdin --stdin-filename "$file" # we only want to lint the staged changes, not any un-staged changes
   if [ $? -ne 0 ]; then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,7 +6,7 @@ yarn run pretty-quick:staged
 
 # ESlint staged files
 # src: https://gist.github.com/dahjelle/8ddedf0aebd488208a9a7c829f19b9e8
-for file in $(git diff --cached --name-only | grep -E '\.(js|jsx|vue)$')
+for file in $(git diff --cached --name-only | grep -E '\.(js|cjs|mjs|jsx|vue)$')
 do
   git show ":$file" | node_modules/.bin/eslint --stdin --stdin-filename "$file" # we only want to lint the staged changes, not any un-staged changes
   if [ $? -ne 0 ]; then

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:e2e": "npm run cypress:headless",
     "test:unit": "npm run jest",
     "test": "npm run test:unit && npm run test:e2e",
-    "lint": "eslint './**/*.{js,vue}'",
+    "lint": "eslint './**/*.{js,mjs,cjs,vue}'",
     "prettier:check": "prettier --check .",
     "prettier:write": "prettier --write .",
     "pretty-quick": "pretty-quick",

--- a/resources/assets/js/views/HomePage/ChimeCard.vue
+++ b/resources/assets/js/views/HomePage/ChimeCard.vue
@@ -1,10 +1,5 @@
 <template>
-  <Card
-    class="chime-card"
-    :icon="showMoveIcon ? 'drag_handle' : ''"
-    iconClass="handle"
-    v-show="showCard"
-  >
+  <Card class="chime-card" v-show="showCard">
     <router-link :to="to">
       <header class="chime-card__header">
         <h1 class="chime-card__title">

--- a/resources/assets/js/views/HomePage/ChimePanel.vue
+++ b/resources/assets/js/views/HomePage/ChimePanel.vue
@@ -83,13 +83,11 @@ import orderBy from "lodash/orderBy";
 import { EventBus } from "../../EventBus.js";
 import ChimeCard from "./ChimeCard.vue";
 import ChimeManagementOptions from "../../components/ChimeManagementOptions.vue";
-import draggable from "vuedraggable";
 
 export default {
   components: {
     ChimeCard,
     ChimeManagementOptions,
-    draggable,
   },
   props: ["user"],
   data() {

--- a/resources/assets/js/views/HomePage/ChimePanel.vue
+++ b/resources/assets/js/views/HomePage/ChimePanel.vue
@@ -54,7 +54,7 @@
             </div>
           </div>
         </form>
-        <draggable v-if="chimes.length > 0" class="chime-card-group">
+        <div v-if="chimes.length > 0" class="chime-card-group">
           <ChimeCard
             v-for="chime in orderedChimes"
             class="chime-card-group__item"
@@ -64,7 +64,7 @@
             :to="getUserLinkToChime({ user, chime })"
             @change="get_chimes"
           />
-        </draggable>
+        </div>
         <div v-else class="my-3">
           <p v-if="user.guest_user">
             You're currently browsing as a guest. If you have a Chime access


### PR DESCRIPTION
Chime reordering isn't currently supported, but a drag handle was added by **somebody** in a recent UI update. The handle is removed.

Also: Noticed that husky's pre-commit script wasn't catching lint errors that would be caught in CI tests. So, I updated husky pre-commit to run eslint on `vue`, `mjs`, and `cjs` files in addition to `js`.

Before / After
<img width="400" alt="Screen Shot 2021-12-16 at 2 57 14 PM" src="https://user-images.githubusercontent.com/980170/146448087-1023860a-c7fb-4331-b8f4-356bb88e0397.png">
<img width="400" alt="Screen Shot 2021-12-16 at 2 53 59 PM" src="https://user-images.githubusercontent.com/980170/146448095-617d0bcd-89b4-4970-b846-0930f3152408.png">


