### PR TITLE
Fix chime header layout with long names

### DIFF
--- a/resources/assets/js/views/ChimePage/ChimePage.vue
+++ b/resources/assets/js/views/ChimePage/ChimePage.vue
@@ -249,7 +249,7 @@ export default {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  flex-wrap: wrap;
+  /* flex-wrap: wrap; */
   gap: 1rem;
 }
 .chime__name {

--- a/resources/assets/js/views/ChimePage/ChimePage.vue
+++ b/resources/assets/js/views/ChimePage/ChimePage.vue
@@ -4,20 +4,19 @@
     <ErrorDialog />
     <div class="container">
       <header class="chime__header">
+        <Chip
+          v-if="true || isCanvasChime"
+          class="chime-header__canvas-chip"
+          color="yellow"
+          :solid="true"
+          title="This chime is linked with Canvas."
+        >
+          Canvas
+        </Chip>
         <div class="chime__header-container">
-          <div class="flex">
-            <h1 class="chime__name">
-              {{ chime.name }}
-            </h1>
-            <Chip
-              v-if="isCanvasChime"
-              color="yellow"
-              :solid="true"
-              title="This chime is linked with Canvas."
-            >
-              Canvas
-            </Chip>
-          </div>
+          <h1 class="chime__name">
+            {{ chime.name }}
+          </h1>
           <div
             class="chime__control-buttons btn-group"
             role="group"
@@ -27,7 +26,12 @@
             }"
           >
             <button
-              class="btn btn-outline-secondary align-items-center d-flex"
+              class="
+                chime__control-button
+                btn btn-outline-secondary
+                align-items-center
+                d-flex
+              "
               :class="{ 'btn--is-active': showSettings }"
               data-cy="toggle-chime-settings-panel"
               @click="toggle('showSettings', { setToFalse: ['exportPanel'] })"
@@ -36,7 +40,12 @@
             </button>
 
             <button
-              class="btn btn-outline-secondary align-items-center d-flex"
+              class="
+                chime__control-button
+                btn btn-outline-secondary
+                align-items-center
+                d-flex
+              "
               :class="{ 'btn--is-active': exportPanel }"
               data-cy="toggle-chime-export-panel"
               @click="toggle('exportPanel', { setToFalse: ['showSettings'] })"
@@ -232,17 +241,25 @@ export default {
 .chime__header {
   margin: 2rem 0 2rem;
 }
+.chime-header__canvas-chip {
+  margin-bottom: 0.5rem;
+}
 
 .chime__header-container {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 .chime__name {
   font-size: 2rem;
   line-height: 1;
   margin: 0;
   margin-right: 0.5rem;
+}
+.chime__control-buttons {
+  flex-shrink: 0;
 }
 
 .chime__control-buttons .material-icons {


### PR DESCRIPTION
- prevent shrinkage of chime control button group
- let header container wrap
- move canvas chip above course name

Fixes #126

Long Name
<img width="921" alt="Screen Shot 2022-01-11 at 5 38 19 PM" src="https://user-images.githubusercontent.com/980170/149039054-eea26bbd-0ddd-4e41-9fe3-493c89f39b37.png">

With Canvas Chip
<img width="908" alt="Screen Shot 2022-01-11 at 5 38 40 PM" src="https://user-images.githubusercontent.com/980170/149039091-87c99f3d-db04-40d2-8a88-e53777516fcd.png">

Short name
<img width="919" alt="Screen Shot 2022-01-11 at 5 37 58 PM" src="https://user-images.githubusercontent.com/980170/149039122-dd6d41a2-b442-4ce7-94b8-425b3d655863.png">


