### PR TITLE
fix Add Folder button layout on small screens

### DIFF
--- a/resources/assets/js/views/ChimePage/ChimePage.vue
+++ b/resources/assets/js/views/ChimePage/ChimePage.vue
@@ -254,7 +254,6 @@ export default {
 }
 .chime__name {
   font-size: 2rem;
-  line-height: 1;
   margin: 0;
   margin-right: 0.5rem;
 }

--- a/resources/assets/js/views/ChimePage/NewFolder.vue
+++ b/resources/assets/js/views/ChimePage/NewFolder.vue
@@ -1,30 +1,29 @@
 <template>
   <div class="new-folder">
-    <label for="createFolder" class="text-right visually-hidden col-form-label"
-      >Add Folder</label
+    <label for="createFolder" class="visually-hidden">Add Folder</label>
+    <input
+      id="createFolder"
+      v-model="folder_name"
+      type="text"
+      class="form-control new-folder__input"
+      name="createFolder"
+      placeholder="Folder Name"
+      @keyup.enter="new_folder"
+    />
+    <button
+      data-cy="create-folder-button"
+      type="button"
+      class="
+        new-folder__button
+        btn btn-outline-primary
+        align-items-center
+        d-flex
+      "
+      @click="new_folder"
     >
-    <div class="row">
-      <div class="col-8 col-6-md">
-        <input
-          id="createFolder"
-          v-model="folder_name"
-          type="text"
-          class="form-control new-folder__input"
-          name="createFolder"
-          placeholder="Folder Name"
-          @keyup.enter="new_folder"
-        />
-      </div>
-      <button
-        data-cy="create-folder-button"
-        type="button"
-        class="btn btn-outline-primary align-items-center d-flex"
-        @click="new_folder"
-      >
-        <i class="material-icons">add</i>
-        Add Folder
-      </button>
-    </div>
+      <i class="material-icons">add</i>
+      Add Folder
+    </button>
     <div
       v-if="chime.lti_grade_mode == 'multiple_grades'"
       class="alert alert-warning mt-2"
@@ -40,9 +39,14 @@
     </div>
   </div>
 </template>
-<style>
+<style scoped>
 .new-folder {
-  max-width: 40rem;
+  max-width: 30rem;
+  display: flex;
+  gap: 1rem;
+}
+.new-folder__button {
+  flex-shrink: 0;
 }
 </style>
 

--- a/resources/assets/js/views/ChimePage/NewFolder.vue
+++ b/resources/assets/js/views/ChimePage/NewFolder.vue
@@ -43,7 +43,7 @@
 .new-folder {
   max-width: 30rem;
   display: flex;
-  gap: 1rem;
+  gap: 0.5rem;
 }
 .new-folder__button {
   flex-shrink: 0;


### PR DESCRIPTION
This fixes an issue where the "Add Folder" button drops down weird on small screens:

BEFORE / AFTER
<img width="300" alt="Screen Shot 2022-01-13 at 3 59 10 PM" src="https://user-images.githubusercontent.com/980170/149415851-e4dba2c4-014b-4430-bb67-1efa4a03185f.png">  <img width="300" alt="Screen Shot 2022-01-13 at 4 02 50 PM" src="https://user-images.githubusercontent.com/980170/149416167-c320c8bf-44ff-4d9b-a632-7174461955c6.png">


