### PR TITLE
Collapse action buttons to vertical ellipses ⋮ dropdown on small screen sizes

### DIFF
--- a/resources/assets/js/components/Chip.vue
+++ b/resources/assets/js/components/Chip.vue
@@ -47,6 +47,7 @@ export default {
   --color-inverse: #fff;
   display: inline-flex;
   flex-wrap: nowrap;
+  white-space: nowrap;
   align-items: center;
   color: var(--color);
   border: 1px solid var(--color);

--- a/resources/assets/js/views/FolderPage/QuestionCard.vue
+++ b/resources/assets/js/views/FolderPage/QuestionCard.vue
@@ -4,22 +4,31 @@
     :icon="showMoveIcon ? 'drag_handle' : ''"
     iconClass="handle"
   >
-    <footer class="question-card__footer">
-      <span class="question-card__question-type">{{
-        questionTypeToString
-      }}</span>
+    <header class="question-card__header">
+      <h2 class="question-card__question-type">
+        <router-link
+          :to="`/chime/${folder.chime_id}/folder/${folder.id}/present/${orderedQuestionIndex}`"
+        >
+          {{ questionTypeToString }}
+        </router-link>
+      </h2>
       <Chip :color="totalResponses ? 'primary' : 'muted'" :solid="true"
         >{{ totalResponses }} {{ "Response" | pluralize(totalResponses) }}</Chip
       >
-    </footer>
-    <div class="flow-text question_list_text" v-html="question.text" />
+    </header>
 
-    <component
-      v-if="hasSpecializedQuestionDisplay(questionType)"
-      class="question-card__choice-display"
-      :is="`${questionType}_display`"
-      :question="question"
-    />
+    <router-link
+      :to="`/chime/${folder.chime_id}/folder/${folder.id}/present/${orderedQuestionIndex}`"
+    >
+      <div class="flow-text question_list_text" v-html="question.text" />
+
+      <component
+        v-if="hasSpecializedQuestionDisplay(questionType)"
+        class="question-card__choice-display"
+        :is="`${questionType}_display`"
+        :question="question"
+      />
+    </router-link>
 
     <QuestionForm
       v-if="showEdit"
@@ -42,25 +51,49 @@
         {{ isOpen ? "Open" : "Closed" }}
       </Toggle>
 
-      <CardActionButton
-        data-cy="edit-question-button"
-        icon="edit"
-        @click="handleEditClick"
-        >Edit</CardActionButton
-      >
+      <div class="dropdown question-card__dropdown">
+        <button
+          type="button"
+          data-toggle="dropdown"
+          aria-expanded="false"
+          class="question-card__dropdown-button"
+        >
+          <i class="material-icons">more_vert</i>
+        </button>
+        <ul
+          class="dropdown-menu dropdown-menu-right question-card__dropdown-list"
+          aria-labelledby="moreOptionsDropdownButton"
+        >
+          <li>
+            <CardActionButton
+              class="dropdown-item question-card__action-button"
+              data-cy="edit-question-button"
+              icon="edit"
+              @click="handleEditClick"
+              >Edit</CardActionButton
+            >
+          </li>
 
-      <CardActionButton
-        data-cy="present-question-button"
-        icon="play_circle_outline"
-        :to="`/chime/${folder.chime_id}/folder/${folder.id}/present/${orderedQuestionIndex}`"
-        >Present</CardActionButton
-      >
-      <CardActionButton
-        data-cy="delete-question-button"
-        icon="clear"
-        @click="handleDeleteClick"
-        >Delete</CardActionButton
-      >
+          <li>
+            <CardActionButton
+              class="dropdown-item question-card__action-button"
+              data-cy="present-question-button"
+              icon="play_circle_outline"
+              :to="`/chime/${folder.chime_id}/folder/${folder.id}/present/${orderedQuestionIndex}`"
+              >Present</CardActionButton
+            >
+          </li>
+          <li>
+            <CardActionButton
+              class="dropdown-item question-card__action-button"
+              data-cy="delete-question-button"
+              icon="clear"
+              @click="handleDeleteClick"
+              >Delete</CardActionButton
+            >
+          </li>
+        </ul>
+      </div>
     </template>
   </Card>
 </template>
@@ -201,10 +234,12 @@ export default {
   font-size: 0.8rem;
   font-weight: bold;
 }
-.question-card__footer {
+.question-card__header {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: baseline;
+  gap: 0.25rem;
   margin-bottom: 1rem;
 }
 
@@ -228,6 +263,41 @@ export default {
 
 .total-responses__number {
   font-size: 3rem;
+}
+
+.question-card .question-card__action-button {
+  flex-direction: row;
+  justify-content: left;
+  gap: 0.5rem;
+  padding: 0.25rem 1rem;
+}
+.question-card__dropdown-button {
+  display: block;
+  border: 0;
+  background: transparent;
+  padding: 0.8rem 0;
+}
+
+@media (min-width: 48rem) {
+  .question-card__dropdown .dropdown-menu {
+    display: flex;
+    position: initial;
+    z-index: initial;
+    float: initial;
+    min-width: initial;
+    padding: 0;
+    margin: 0;
+    background-color: transparent;
+    border: 0;
+  }
+  .question-card .question-card__action-button {
+    flex-direction: column;
+    gap: 0;
+    padding: 0.75rem;
+  }
+  .question-card__dropdown-button {
+    display: none;
+  }
 }
 </style>
 <style>


### PR DESCRIPTION
Resolves #148. 

- Collapses action buttons (not close) to vertical dots style "more" menu on smaller screen sizes.
<img width="250" alt="Screen Shot 2022-01-25 at 12 15 41 PM" src="https://user-images.githubusercontent.com/980170/151035458-f8e0d623-01b0-4f4b-ac13-4c2fd56306cf.png"><img width="250" alt="Screen Shot 2022-01-25 at 12 15 50 PM" src="https://user-images.githubusercontent.com/980170/151035463-21de1f96-46e6-418e-b863-fef7a39742bc.png">

- Also, added an action to jump to "Present" view when the card's text is clicked. Previously, there was no action when a card is clicked, which could be confusing – especially if most actions are hidden in the collapsed menu. "Present view" seemed like a good default action on click.


