### PR TITLE
add a warning if a student accesses a canvas-linked course directly

### DIFF
--- a/app/Http/Controllers/LTIHandler.php
+++ b/app/Http/Controllers/LTIHandler.php
@@ -35,6 +35,7 @@ class LTIHandler extends Controller
         
         $tool = new ChimeToolProvider();
         $tool->handleRequest();
+        session(['lti_launch' => true]);
         $launchDomain = $tool->resourceLink->getSetting("custom_canvas_api_domain");
         if(!\App::environment('local') && !in_array($launchDomain, $this->allowedDomains)) {
             abort(401, 'LTI Launch from an invalid domain');

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -174,7 +174,7 @@ export default {
       return [...this.responses].sort(compare);
     },
     ltiLaunchWarning: function () {
-      if (!window.lti_launch && this.isCanvasChime) {
+      if (!this.inParticipantView && !window.lti_launch && this.isCanvasChime) {
         return true;
       }
       return false;

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -40,8 +40,8 @@
               <div v-if="ltiLaunchWarning" class="text-center">
                 <h1>Chime Access Method Invalid</h1>
                 <p class="text-left">
-                  In respond to questions in this Chime, you must follow the
-                  link from your
+                  In order to respond to questions in this Chime, you must
+                  follow the link from your
                   <a :href="canvasCourseUrl">course Canvas site</a>. You can
                   still access your previously answered questions using the tab
                   above.

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -269,12 +269,15 @@ export default {
             );
             console.log("error getting chime:", err.response);
           }
+        })
+        .then(() => {
+          return axios
+            .get("/api/chime/" + this.chimeId + "/responses")
+            .then((res) => {
+              console.log("debug", "Response:", res);
+              this.responses = res.data;
+            });
         });
-
-      axios.get("/api/chime/" + this.chimeId + "/responses").then((res) => {
-        console.log("debug", "Response:", res);
-        this.responses = res.data;
-      });
     },
   },
 };

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -5,7 +5,7 @@
       :canvasUrl="canvasCourseUrl"
       :joinUrl="joinUrl"
     />
-    <NavBar title="Home" :user="user" :link="'/'" v-if="!isCanvasChime" />
+    <NavBar :title="isCanvasChime ? null : 'Home'" :user="user" link="/" />
     <ErrorDialog />
     <div v-if="error" class="alert alert-warning" role="alert">
       {{ error }}
@@ -102,6 +102,9 @@
 <style scoped>
 .nav-item {
   width: 50%;
+}
+.container {
+  margin-top: 1em;
 }
 </style>
 <script>

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -25,7 +25,7 @@
             </li>
             <li class="nav-item">
               <a class="nav-link" data-toggle="tab" href="#pastQuestions"
-                >Closed Questions</a
+                >Answered Questions</a
               >
             </li>
           </ul>
@@ -44,20 +44,32 @@
               >
                 <h1>No Open Questions</h1>
               </div>
-              <transition-group v-if="filteredSession.length > 0" name="fade">
-                <ParticipantPrompt
-                  v-for="s in filteredSession"
-                  :key="s.id"
-                  :session="s"
-                  :chime="chime"
-                  :responses="responses"
-                  @updateResponse="updateResponse"
-                />
-              </transition-group>
+              <div v-if="ltiLaunchWarning" class="text-center">
+                <h1>Chime Access Method Invalid</h1>
+                <p class="text-left">
+                  In respond to questions in this Chime, you must follow the
+                  link from your
+                  <a :href="canvasCourseUrl">course Canvas site</a>. You can
+                  still access your previously answered questions using the tab
+                  above.
+                </p>
+              </div>
+              <template v-else>
+                <transition-group v-if="filteredSession.length > 0" name="fade">
+                  <ParticipantPrompt
+                    v-for="s in filteredSession"
+                    :key="s.id"
+                    :session="s"
+                    :chime="chime"
+                    :responses="responses"
+                    @updateResponse="updateResponse"
+                  />
+                </transition-group>
+              </template>
             </div>
             <div id="pastQuestions" class="tab-pane container">
               <div v-if="responses.length < 1" class="text-center">
-                <h1>No Closed Questions</h1>
+                <h1>No Answered Questions</h1>
               </div>
               <Response
                 v-else
@@ -68,7 +80,7 @@
               />
             </div>
           </div>
-          <p class="text-center m-0">
+          <p class="text-center m-0" v-if="!ltiLaunchWarning">
             <small v-if="chime.lti_course_title" class="text-muted"
               >Not seeing the prompts you're looking for? Make sure you've
               followed the correct assignment link from Canvas.
@@ -102,6 +114,7 @@ import ViewModeNotice from "./ViewModeNotice.vue";
 import {
   selectCanvasCourseUrl,
   selectJoinUrl,
+  selectIsCanvasChime,
 } from "../../helpers/chimeSelectors.js";
 
 export default {
@@ -153,6 +166,12 @@ export default {
       }
 
       return [...this.responses].sort(compare);
+    },
+    ltiLaunchWarning: function () {
+      if (!window.lti_launch && selectIsCanvasChime(this.chime)) {
+        return true;
+      }
+      return false;
     },
   },
   mounted: function () {

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -5,7 +5,7 @@
       :canvasUrl="canvasCourseUrl"
       :joinUrl="joinUrl"
     />
-    <NavBar title="Home" :user="user" :link="'/'" />
+    <NavBar title="Home" :user="user" :link="'/'" v-if="!isCanvasChime" />
     <ErrorDialog />
     <div v-if="error" class="alert alert-warning" role="alert">
       {{ error }}
@@ -37,13 +37,6 @@
               class="tab-pane container active"
               aria-live="polite"
             >
-              <div
-                v-if="filteredSession.length < 1"
-                key="none"
-                class="text-center"
-              >
-                <h1>No Open Questions</h1>
-              </div>
               <div v-if="ltiLaunchWarning" class="text-center">
                 <h1>Chime Access Method Invalid</h1>
                 <p class="text-left">
@@ -55,6 +48,13 @@
                 </p>
               </div>
               <template v-else>
+                <div
+                  v-if="filteredSession.length < 1"
+                  key="none"
+                  class="text-center"
+                >
+                  <h1>No Open Questions</h1>
+                </div>
                 <transition-group v-if="filteredSession.length > 0" name="fade">
                   <ParticipantPrompt
                     v-for="s in filteredSession"
@@ -143,6 +143,9 @@ export default {
     joinUrl() {
       return selectJoinUrl(this.chime);
     },
+    isCanvasChime() {
+      return selectIsCanvasChime(this.chime);
+    },
     inParticipantView() {
       const viewMode = get(this, "$route.query.viewMode", null);
       if (!viewMode) return false;
@@ -168,7 +171,7 @@ export default {
       return [...this.responses].sort(compare);
     },
     ltiLaunchWarning: function () {
-      if (!window.lti_launch && selectIsCanvasChime(this.chime)) {
+      if (!window.lti_launch && this.isCanvasChime) {
         return true;
       }
       return false;

--- a/resources/views/base.blade.php
+++ b/resources/views/base.blade.php
@@ -146,6 +146,7 @@
 				</body>
 				
 				<script>window.pusherKey = '{{ env('PUSHER_APP_KEY') }}'</script>
+				<script>window.lti_launch = '{{ session('lti_launch') }}'</script>
 				<script src="{{ mix('js/app.js') }}"></script>
 
 				@yield('footer')


### PR DESCRIPTION
Adds a warning for non-Canvas access to Canvas-linked courses. Still allows access to previous questions.

In addition:

- changes "closed questions" to "answered questions"
- removes home link for Canvas-linked courses
<img width="1552" alt="Screen Shot 2022-01-27 at 5 39 12 PM" src="https://user-images.githubusercontent.com/211655/151461328-840c695a-7b91-4179-893a-e1b16870105d.png">

