### PR TITLE
Return actual errors and draw them more clearly

### DIFF
--- a/app/Http/Controllers/ResponseController.php
+++ b/app/Http/Controllers/ResponseController.php
@@ -40,11 +40,11 @@ class ResponseController extends Controller
         $chime = $user->chimes()->find($chime->id);
 
         if(!$chime->sessions()->contains($session)) {
-            return response()->json(["message"=>'Session not found'], 403);
+            return response()->json(["message"=>'Session not found.'], 403);
         }
 
         if(!$session->question->current_session || $session->question->current_session->id != $session->id) {
-            return response()->json(["message"=>'Session has been closed'], 403);
+            return response()->json(["message"=>'Session has been closed.'], 403);
         }
         
         if($response) {
@@ -52,7 +52,7 @@ class ResponseController extends Controller
         }
         else {
             if(!$request->get("response_info")) {
-                return response()->json(["message"=>'Responses cannot be blank'], 400);
+                return response()->json(["message"=>'Responses cannot be blank.'], 400);
             }
             $response = $session->responses()->create([
                 'response_info' => $request->get('response_info'),

--- a/app/Http/Controllers/ResponseController.php
+++ b/app/Http/Controllers/ResponseController.php
@@ -40,14 +40,11 @@ class ResponseController extends Controller
         $chime = $user->chimes()->find($chime->id);
 
         if(!$chime->sessions()->contains($session)) {
-            // TODO ERROR
-            dd($chime
-            ->sessions());
-            return "nope";
+            return response('Session not found', 403);
         }
 
         if(!$session->question->current_session || $session->question->current_session->id != $session->id) {
-            return "nope";
+            return response('Session has been closed', 403);
         }
         
         if($response) {

--- a/app/Http/Controllers/ResponseController.php
+++ b/app/Http/Controllers/ResponseController.php
@@ -40,11 +40,11 @@ class ResponseController extends Controller
         $chime = $user->chimes()->find($chime->id);
 
         if(!$chime->sessions()->contains($session)) {
-            return response('Session not found', 403);
+            return response()->json(["message"=>'Session not found'], 403);
         }
 
         if(!$session->question->current_session || $session->question->current_session->id != $session->id) {
-            return response('Session has been closed', 403);
+            return response()->json(["message"=>'Session has been closed'], 403);
         }
         
         if($response) {
@@ -52,7 +52,7 @@ class ResponseController extends Controller
         }
         else {
             if(!$request->get("response_info")) {
-                return response('Responses cannot be blank', 400);
+                return response()->json(["message"=>'Responses cannot be blank'], 400);
             }
             $response = $session->responses()->create([
                 'response_info' => $request->get('response_info'),

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -116,6 +116,7 @@
 <style scoped>
 .nav-item {
   width: 50%;
+  align-self: flex-end;
 }
 .container {
   margin-top: 1em;

--- a/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
@@ -110,7 +110,13 @@ export default {
             this.error =
               "Error recording response. Your internet connection may be down. ";
           } else {
-            this.error = err.response;
+            if (err.response.data && err.response.data.message) {
+              this.error = err.response.data.message;
+              this.error +=
+                " Please try reloading the page, or contact help@umn.edu. If possible, include a screenshot of this error";
+            } else {
+              this.error = err.response;
+            }
           }
         });
     },

--- a/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
@@ -15,7 +15,11 @@
       <transition name="fade">
         <p v-if="responseUpdated" class="alert alert-info">Response Updated</p>
       </transition>
-      <p v-if="error" class="alert alert-warning">{{ error }} Please reload.</p>
+      <p v-if="error" class="alert alert-warning">
+        {{ error }} Please try reloading the page, or contact
+        <a href="mailto:help@umn.edu">help@umn.edu</a>. If possible, include a
+        screenshot of this error.
+      </p>
 
       <small
         v-if="chime.show_folder_title_to_participants"
@@ -112,8 +116,6 @@ export default {
           } else {
             if (err.response.data && err.response.data.message) {
               this.error = err.response.data.message;
-              this.error +=
-                " Please try reloading the page, or contact help@umn.edu. If possible, include a screenshot of this error";
             } else {
               this.error = err.response;
             }


### PR DESCRIPTION
These are mostly cases where a user loses connectivity while submitting a response, or they've lost the web socket and the question has closed. Previously they got a full backtrace. Now they'll get a nicer error with a clear next step for them.


![IMG_4027](https://user-images.githubusercontent.com/211655/151878874-e02b7beb-42de-4a5a-a209-332ca9ec0963.PNG)

