### PR TITLE
[Text Heatmap] Show highlightable text in presenter view and on question cards

### DIFF
--- a/resources/assets/js/components/TextHeatmap/TextHeatmapResponseDisplay.vue
+++ b/resources/assets/js/components/TextHeatmap/TextHeatmapResponseDisplay.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="text-heatmap-response-display" v-html="heatmapText"></div>
+</template>
+
+<script>
+export default {
+  props: ["question"],
+  computed: {
+    heatmapText() {
+      return this.question.question_info.question_responses.heatmap_text;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.text-heatmap-response-display {
+  padding-left: 1rem;
+  border-left: 0.25rem solid #ddd;
+  font-size: 0.8rem;
+}
+</style>

--- a/resources/assets/js/components/TextHeatmap/TextHeatmapResponseDisplay.vue
+++ b/resources/assets/js/components/TextHeatmap/TextHeatmapResponseDisplay.vue
@@ -17,6 +17,6 @@ export default {
 .text-heatmap-response-display {
   padding-left: 1rem;
   border-left: 0.25rem solid #ddd;
-  font-size: 0.8rem;
+  font-size: 0.8em;
 }
 </style>

--- a/resources/assets/js/helpers/hasSpecializedQuestionDisplay.js
+++ b/resources/assets/js/helpers/hasSpecializedQuestionDisplay.js
@@ -2,5 +2,9 @@
  * if question requires additional component for rendering prompt
  */
 export default (questionType) => {
-  return ["multiple_choice", "heatmap_response"].includes(questionType);
+  return [
+    "multiple_choice",
+    "heatmap_response",
+    "text_heatmap_response",
+  ].includes(questionType);
 };

--- a/resources/assets/js/views/FolderPage/QuestionCard.vue
+++ b/resources/assets/js/views/FolderPage/QuestionCard.vue
@@ -221,6 +221,9 @@ export default {
 </script>
 
 <style scoped>
+.question-card {
+  line-height: 1.4;
+}
 .open-question-toggle {
   display: flex;
   flex-direction: column;

--- a/resources/assets/js/views/FolderPage/QuestionCard.vue
+++ b/resources/assets/js/views/FolderPage/QuestionCard.vue
@@ -107,6 +107,7 @@ import QuestionForm from "../QuestionForm/QuestionForm.vue";
 import MultipleChoiceDisplay from "../../components/MultipleChoice/MultipleChoiceDisplay.vue";
 import HeatmapResponseDisplay from "../../components/ImageHeatmapResponse/ImageHeatmapResponseDisplay.vue";
 import hasSpecializedQuestionDisplay from "../../helpers/hasSpecializedQuestionDisplay";
+import TextHeatmapResponseDisplay from "../../components/TextHeatmap/TextHeatmapResponseDisplay.vue";
 
 export default {
   components: {
@@ -117,6 +118,7 @@ export default {
     QuestionForm,
     multiple_choice_display: MultipleChoiceDisplay,
     heatmap_response_display: HeatmapResponseDisplay,
+    text_heatmap_response_display: TextHeatmapResponseDisplay,
   },
   props: {
     folder: {

--- a/resources/assets/js/views/PresentPage/PresentPrompt.vue
+++ b/resources/assets/js/views/PresentPage/PresentPrompt.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="questionContent row">
+  <div class="present-prompt questionContent row">
     <div v-if="question" class="col">
       <h1 v-html="question.text"></h1>
       <component
@@ -20,11 +20,13 @@
 import MultipleChoiceDisplay from "../../components/MultipleChoice/MultipleChoiceDisplay.vue";
 import HeatmapResponseDisplay from "../../components/ImageHeatmapResponse/ImageHeatmapResponseDisplay.vue";
 import hasSpecializedQuestionDisplay from "../../helpers/hasSpecializedQuestionDisplay";
+import TextHeatmapResponseDisplay from "../../components/TextHeatmap/TextHeatmapResponseDisplay.vue";
 
 export default {
   components: {
     multiple_choice_display: MultipleChoiceDisplay,
     heatmap_response_display: HeatmapResponseDisplay,
+    text_heatmap_response_display: TextHeatmapResponseDisplay,
   },
   props: ["question", "session"],
   computed: {
@@ -37,3 +39,8 @@ export default {
   },
 };
 </script>
+<style scoped>
+.present-prompt .text-heatmap-response-display {
+  font-size: 1.2rem;
+}
+</style>


### PR DESCRIPTION
This displays the selectable text in addition to the question prompt for text heatmap questions. Previously, it would show in student view or presenter results view. This adds it to the question card and in presenter view, similar to image heatmap and multiple choice questions. 

Closes #157 

<img width="600" alt="Screen Shot 2022-02-01 at 12 04 34 PM" src="https://user-images.githubusercontent.com/980170/152026826-78789e17-4aa8-452c-ac97-8ce61374dbae.png">
<img width="600" alt="Screen Shot 2022-02-01 at 12 04 24 PM" src="https://user-images.githubusercontent.com/980170/152026947-3f8d83e5-8b3f-49d3-b685-a2c8a1b6e7db.png">

