### PR TITLE
Fix for multiple responses not selecting the highest value

### DIFF
--- a/app/Library/LTI13Processor.php
+++ b/app/Library/LTI13Processor.php
@@ -253,7 +253,9 @@ class LTI13Processor {
 					}
 				);
 			}
-		)->flatten(1)->reduce(function($carry, $item) {
+		)->flatten(1)->filter(function($score) {
+			return $score !== false;
+		})->reduce(function($carry, $item) {
 			$user = $item["user"];
 			$submission_date = $item["submission_date"];
 			$points = $item["points"];

--- a/app/Library/LTI13Processor.php
+++ b/app/Library/LTI13Processor.php
@@ -255,13 +255,16 @@ class LTI13Processor {
 			}
 		)->flatten(1)->reduce(function($carry, $item) {
 			$user = $item["user"];
+			$submission_date = $item["submission_date"];
+			$points = $item["points"];
+			
 			if(!isset($carry[$user->id])) {
-				$carry[$user->id] = ["user"=>$user, "points"=>0, "submission_date"=>$item["submission_date"]];
+				$carry[$user->id] = ["user"=>$user, "points"=>0, "submission_date"=>$submission_date];
 			}
 			// make sure we grant student the max possible results
-			if($item["points"] > $carry[$user->id]["points"]) {
-				$carry[$user->id]["points"] = $item["points"];
-				$carry[$user->id]["submission_date"] = $item["submission_date"];
+			if($points > $carry[$user->id]["points"]) {
+				$carry[$user->id]["points"] = $points;
+				$carry[$user->id]["submission_date"] = $submission_date;
 			}
 			return $carry;
 		}, []);

--- a/app/Library/LTI13Processor.php
+++ b/app/Library/LTI13Processor.php
@@ -253,16 +253,18 @@ class LTI13Processor {
 					}
 				);
 			}
-		)->flatten(1)->unique(
-			function ($userCollection) {
-				if(isset($userCollection["user"])) {
-					return $userCollection["user"]->id;
-				}
-				else {
-					return $userCollection;
-				}
+		)->flatten(1)->reduce(function($carry, $item) {
+			$user = $item["user"];
+			if(!isset($carry[$user->id])) {
+				$carry[$user->id] = ["user"=>$user, "points"=>0, "submission_date"=>$item["submission_date"]];
 			}
-		);
+			// make sure we grant student the max possible results
+			if($item["points"] > $carry[$user->id]["points"]) {
+				$carry[$user->id]["points"] = $item["points"];
+				$carry[$user->id]["submission_date"] = $item["submission_date"];
+			}
+			return $carry;
+		}, []);
 		
 		foreach($users as $userCollection) {
 			$user = $userCollection["user"];


### PR DESCRIPTION
As described in tkt.umn.edu/714903, if a Chime is using the half points participation / full points for correct answer model, and the same question is asked multiple times, we don't currently report the highest outcome achieved. Instead, it's basically nondeterministic.

This PR adds a reduce stage to our point computation which uses the max value a student achieved across all the sessions for a course.