### PR TITLE
On error modal, add a big obvious button to go to home page

### DIFF
--- a/resources/assets/js/components/ErrorDialog.vue
+++ b/resources/assets/js/components/ErrorDialog.vue
@@ -1,11 +1,18 @@
 <template>
-  <Modal :show="$store.getters.message" style="z-index: 15000">
+  <Modal
+    :show="$store.getters.message"
+    style="z-index: 15000"
+    :closeable="false"
+  >
     <div class="alert alert-danger" role="alert">
       <strong>Error: </strong> {{ $store.getters.message }} Refresh your
       browser, or return to the <router-link to="/">home page</router-link> to
-      try again. If the error continues, please
-      <a href="mailto:clatel@umn.edu">get in touch</a>.
+      try again. If the error continues, please email
+      <a href="mailto:help@umn.edu">help@umn.edu</a>.
     </div>
+
+    <!-- Use real link rather than router-link to reload page-->
+    <a href="/" class="btn btn-primary">Go to Home Page</a>
   </Modal>
 </template>
 

--- a/resources/assets/js/components/Modal.vue
+++ b/resources/assets/js/components/Modal.vue
@@ -2,7 +2,7 @@
   <transition name="modal">
     <div v-show="show" class="modal-mask" @mousedown="close">
       <div class="modal-container" @mousedown.stop>
-        <button @click="close" class="modal__close-button">
+        <button v-if="closeable" @click="close" class="modal__close-button">
           <i class="material-icons">close</i>
           <span class="sr-only">Close</span>
         </button>
@@ -14,7 +14,7 @@
 
 <script>
 export default {
-  props: ["show"],
+  props: ["show", "closeable"],
   mounted: function () {
     document.addEventListener("keydown", (e) => {
       if (this.show && e.keyCode == 27) {


### PR DESCRIPTION
Small changes, but since I spend more time than average on the error page and they've been bothering me for a bit:

- Channeling my inner Steve Krug and adding a big obvious blue button to go to homepage.
- Change email from `clatel@umn.edu` to `help@umn.edu`. (I thought we changed the emails... but maybe that was another app or I missed one?)
- Also changed "get in touch" idiom to a more direct "email help@umn.edu". Idioms can be challenging to understand for non-native speakers.

<img width="852" alt="Screen Shot 2022-03-23 at 4 30 35 PM" src="https://user-images.githubusercontent.com/980170/159799211-aec7885f-02eb-42c6-8708-26589f22c9bd.png">

