### PR TITLE
Use docker for installing local php deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,13 @@ cp .env.example .env
 # The default `.env.example` will probably be sufficient,
 # but if you're a Safari user, change SESSION_SAME_SITE="none"
 
-# Instal php deps
-composer install
+# Install php deps
+docker run --rm \
+    -u "$(id -u):$(id -g)" \
+    -v $(pwd):/var/www/html \
+    -w /var/www/html \
+    laravelsail/php81-composer:latest \
+    composer install --ignore-platform-reqs
 
 # Build docker image
 sail build --no-cache


### PR DESCRIPTION
Change from using local composer to using docker container for installing php deps with composer.

Taken from Sail docs:
https://laravel.com/docs/9.x/sail#executing-composer-commands