### PR TITLE
fix: chime options not saving when adding new chime

### DIFF
--- a/resources/assets/js/views/HomePage/ChimePanel.vue
+++ b/resources/assets/js/views/HomePage/ChimePanel.vue
@@ -27,7 +27,7 @@
               <div class="col-sm-8">
                 <input
                   id="chime_name_input"
-                  v-model="chime_name"
+                  v-model="newChime.name"
                   class="form-control"
                   type="text"
                 />
@@ -35,13 +35,14 @@
             </div>
             <div class="row">
               <ChimeManagementOptions
-                v-model:require_login="requireLogin"
-                v-model:students_can_view="studentsCanView"
-                v-model:join_instructions="joinInstructions"
-                v-model:show_folder_title_to_participants="
-                  showFolderTitleToParticipants
+                :require_login="newChime.requireLogin"
+                :students_can_view="newChime.studentsCanView"
+                :join_instructions="newChime.joinInstructions"
+                :show_folder_title_to_participants="
+                  newChime.showFolderTitleToParticipants
                 "
                 :new_chime="true"
+                @update="handleNewChimeOptionsUpdate"
               />
             </div>
             <div class="row">
@@ -87,6 +88,14 @@ import ChimeCard from "./ChimeCard.vue";
 import ChimeManagementOptions from "../../components/ChimeManagementOptions.vue";
 import pluralize from "../../common/pluralize.js";
 
+const newChimeDefaults = {
+  name: "",
+  require_login: false,
+  students_can_view: false,
+  join_instructions: true,
+  show_folder_title_to_participants: false,
+};
+
 export default {
   components: {
     ChimeCard,
@@ -96,12 +105,8 @@ export default {
   emits: ["update:chimes"],
   data() {
     return {
-      requireLogin: false,
-      studentsCanView: false,
-      joinInstructions: true,
-      showFolderTitleToParticipants: false,
+      newChime: { ...newChimeDefaults },
       showAdd: false,
-      chime_name: "",
       modalChime: null,
       isRemoveConfirmOpen: false,
     };
@@ -113,6 +118,12 @@ export default {
   },
   methods: {
     pluralize,
+    handleNewChimeOptionsUpdate(updates) {
+      this.newChime = {
+        ...this.newChime,
+        ...updates,
+      };
+    },
     handleChimeCardChange(payload) {
       this.$emit("update:chimes", payload);
     },
@@ -125,20 +136,16 @@ export default {
         : `/chimeParticipant/${chime.id}`;
     },
     create_chime() {
-      if (this.chime_name.length == 0) {
+      if (this.newChime.name.length == 0) {
         alert("You must enter a name for the Chime");
         return;
       }
+
       axios
-        .post("/api/chime", {
-          name: this.chime_name,
-          require_login: this.requireLogin,
-          students_can_view: this.studentsCanView,
-          join_instructions: this.joinInstructions,
-          show_folder_title_to_participants: this.showFolderTitleToParticipants,
-        })
+        .post("/api/chime", this.newChime)
         .then((res) => {
           this.showAdd = false;
+          this.newChime = { ...newChimeDefaults };
           this.$emit("update:chimes", res.data);
           this.$router.push({
             name: "chime",


### PR DESCRIPTION
This fixes an issue where chime options were not saved when adding a new chime.

## Details
My bad. When fixing the ChimeManagementOptions persistence issue in #261 , I changed from an update handler for each property like: 

```js
emit('update:prop1', val1)
emit('update:prop2', val2)
```

to a single update handler, like so:
```js
emit('update',  { prop1: val1, prop2: val2 })
```

However, the ChimePanel for adding a new chime on the HomePage wasn't updated to match the new `@update` handler, causing updates to not be recorded. This updates the ChimePanel component to match the new pattern. It also puts the new chime props into a single object to make it easier to merge and emitted updates.