### PR TITLE
Fix whitespace between buttons

### DIFF
--- a/webpack.mix.cjs
+++ b/webpack.mix.cjs
@@ -13,7 +13,13 @@ const mix = require("laravel-mix");
 
 mix
   .ts("resources/assets/js/app.ts", "public/js")
-  .vue()
+  .vue({
+    options: {
+      compilerOptions: {
+        whitespace: "preserve",
+      },
+    },
+  })
   .sass("resources/assets/sass/app.scss", "public/css")
   .sourceMaps(true, "source-map");
 


### PR DESCRIPTION
Fixes #295

Vue2 and Vue3 handle whitespace differently. In Vue3, the default is to condense whitespace. This sets the the vue config to `preserve` whitespace, so that buttons snuggle less.

<img width="400" alt="Screen Shot 2022-06-03 at 11 18 36 AM" src="https://user-images.githubusercontent.com/980170/171905864-47cf4d75-8b0a-4a10-8a7a-f861277736c5.png">

<img width="400" alt="Screen Shot 2022-06-03 at 11 18 27 AM" src="https://user-images.githubusercontent.com/980170/171905872-a2aeea20-895a-440b-a4ee-e7b21c3505b4.png">