### PR TITLE
Increase contrast for question type and saved labels in participant view

### DIFF
--- a/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
@@ -208,14 +208,14 @@ export default {
   display: block;
   height: 0.8rem;
   width: 0.8rem;
-  background: #ccc;
+  background: var(--neutral-300);
   position: absolute;
   left: 0;
   top: 0;
 }
 
 .save-succeeded.participant-prompt:before {
-  background: #31d158;
+  background: #3cc03c;
 }
 .is-saving.participant-prompt:before {
   background: var(--gold);
@@ -237,7 +237,7 @@ export default {
 }
 
 .save-succeeded .prompt-header {
-  color: #31d158;
+  color: #008d22;
 }
 .is-saving .prompt-header {
   color: var(--gold);

--- a/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
@@ -229,7 +229,7 @@ export default {
   position: relative;
   text-transform: uppercase;
   font-weight: bold;
-  color: #999;
+  color: var(--neutral-500);
   font-size: 0.8rem;
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
Bumps up the contrast with this secondary text so that it's AA compliant.

Closes #383 

<img width="300" alt="Screen Shot 2022-07-27 at 3 16 25 PM" src="https://user-images.githubusercontent.com/980170/181364583-4967b293-7497-4e2a-b1cb-f7ec22f41dc4.png">

<img width="300" alt="Screen Shot 2022-07-27 at 3 16 35 PM" src="https://user-images.githubusercontent.com/980170/181364594-9451cadd-90e1-4eda-b738-4f467c434f73.png">


