### PR TITLE
Fix Participant View pink border not stretching full height

### DIFF
--- a/resources/assets/js/layouts/DefaultLayout.vue
+++ b/resources/assets/js/layouts/DefaultLayout.vue
@@ -52,7 +52,7 @@ export default {
 
 <style scoped>
 .default-layout {
-  min-height: 100%;
+  min-height: 100vh;
 }
 .default-layout__main {
   padding-bottom: 4rem;

--- a/resources/assets/js/views/ParticipantPage/ViewModeNotice.vue
+++ b/resources/assets/js/views/ParticipantPage/ViewModeNotice.vue
@@ -1,18 +1,18 @@
 <template>
-  <div class="view-mode grid">
+  <div class="view-mode">
     <header class="view-mode__header">
       <i class="material-icons">preview</i>
       <h2 class="view-mode__heading">Participant View</h2>
     </header>
-    <div class="view-mode__description">
-      <p>This is a preview of what your Chime participants will see.</p>
+    <div class="view-mode__description d-none d-md-block">
+      <p>This is a preview of what participants will see.</p>
       <p>
         <a :href="canvasUrl || joinUrl">{{ canvasUrl || joinUrl }}</a>
       </p>
     </div>
     <div>
       <router-link :to="callbackUrl" class="btn btn-outline-secondary">
-        Leave Participant View
+        Leave <span class="d-none d-md-inline">Participant View</span>
       </router-link>
     </div>
   </div>

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -16,7 +16,6 @@
 .fade-enter-active,
 .fade-leave-active {
   transition: all 1s;
-  // position: absolute;
 }
 
 .fade-enter,
@@ -52,18 +51,14 @@
   box-shadow: 2px 2px 18px lightgray;
 }
 
-html {
-  height: 100%;
-}
-
 body {
-  min-height: 100%;
   font-family: "Open Sans", sans-serif;
   color: var(--black);
   line-height: 1.4;
   display: flex;
   flex-direction: column;
 }
+
 main {
   flex-grow: 1;
 }
@@ -147,13 +142,8 @@ img {
   padding: 0 1rem;
 }
 
-html,
-body {
-  height: 100%;
-}
-
 #app {
-  min-height: 100%;
+  min-height: 100vh;
 }
 
 @media (min-width: 50rem) {


### PR DESCRIPTION
- Put `min-height: 100vh` on app instead of `100%` on html, body, etc.
- Participant view bottom bar was squarshed on small screens. This will hide the details until screen is large enough.

Screenshots (ignore the debugbar stuff of course):
<img width="300" alt="Screen Shot 2022-07-29 at 9 03 32 PM" src="https://user-images.githubusercontent.com/980170/181866124-a16d4ae4-0fea-4a69-a61b-9b570c0860ea.png">
<img width="800" alt="Screen Shot 2022-07-29 at 9 03 16 PM" src="https://user-images.githubusercontent.com/980170/181866130-f7fb643e-f056-4ce7-84b0-fa9ad88b2f60.png">

Closes #364.
