### PR TITLE
Add labels and headings to questions prompts

### DIFF
--- a/cypress/integration/ui/guestParticipation.test.js
+++ b/cypress/integration/ui/guestParticipation.test.js
@@ -48,7 +48,7 @@ describe("participating as a guest", () => {
   it("shows no questions if none are open", () => {
     // guests should see no chime open
     cy.visit(`/join/${testChime.access_code}`)
-      .get("#currentQuestions")
+      .get("#open-questions")
       .should("contain.text", "No Open Questions");
   });
 
@@ -61,7 +61,7 @@ describe("participating as a guest", () => {
 
     // check that chime is now available to guests
     cy.visit(`/join/${testChime.access_code}`)
-      .get("#currentQuestions")
+      .get("#open-questions")
       .should("contain.text", testQuestion.text);
 
     cy.get("#radio1_0").click();

--- a/cypress/integration/ui/imageResponseQuestion.test.js
+++ b/cypress/integration/ui/imageResponseQuestion.test.js
@@ -190,7 +190,7 @@ describe("image response", () => {
 
         // both responses should show in the Answered Questions tab
         cy.contains("Answered Questions").click();
-        cy.get("#pastQuestions [data-cy=image-response-thumbnail]").should(
+        cy.get("#answered-questions [data-cy=image-response-thumbnail]").should(
           "have.length",
           2
         );

--- a/cypress/integration/ui/question.test.js
+++ b/cypress/integration/ui/question.test.js
@@ -889,7 +889,7 @@ describe("question", () => {
           cy.visit(`/join/${testChime.access_code}`);
 
           // make sure image is loaded
-          cy.get("#currentQuestions [data-cy=image-heatmap-target]")
+          cy.get("#open-questions [data-cy=image-heatmap-target]")
             .as("image-heatmap-target")
             .should("be.visible")
             .and(($img) => {

--- a/resources/assets/js/components/FreeResponse/FreeResponseInputs.vue
+++ b/resources/assets/js/components/FreeResponse/FreeResponseInputs.vue
@@ -3,6 +3,7 @@
     <div class="form-group">
       <textarea
         v-model="response_text"
+        :aria-labelledby="`question-${question.id}-heading`"
         data-cy="free-response-textarea"
         class="form-control"
         placeholder="Type your response"

--- a/resources/assets/js/components/ImageResponse/ImageResponseInputs.vue
+++ b/resources/assets/js/components/ImageResponse/ImageResponseInputs.vue
@@ -21,6 +21,7 @@
       <div class="dropbox-group">
         <ImageUploadDropbox
           v-if="chime"
+          :aria-labelledby="`question-${question.id}-heading`"
           class="dropbox-group__uploader"
           :imageSrc="tempImagePath"
           :uploadTo="`/api/chime/${chime.id}/image`"

--- a/resources/assets/js/components/MultipleChoice/MultipleChoiceInputs.vue
+++ b/resources/assets/js/components/MultipleChoice/MultipleChoiceInputs.vue
@@ -1,6 +1,10 @@
 <template>
   <div data-cy="multiple-choice-participant-choices">
-    <fieldset class="form-group" role="radiogroup">
+    <fieldset
+      class="form-group"
+      role="radiogroup"
+      :aria-labelledby="`question-${question.id}-heading`"
+    >
       <div v-for="(option, key) in selectOptions" :key="key" class="form-check">
         <input
           :id="'radio' + question.id + '_' + key"

--- a/resources/assets/js/components/SliderResponse/SliderResponseInputs.vue
+++ b/resources/assets/js/components/SliderResponse/SliderResponseInputs.vue
@@ -5,10 +5,13 @@
         <div class="range-wrap">
           <input
             id="formControlRange"
+            :aria-labelledby="`question-${question.id}-heading`"
             type="range"
             :disabled="disabled"
             class="form-control-range custom-range range"
             :value="sliderValue"
+            :min="left_choice_text"
+            :max="right_choice_text"
             data-cy="slider-response-input"
             @change="valueChanged($event.target.value)"
           />

--- a/resources/assets/js/components/TextHeatmap/TextHeatmapResponseInputs.vue
+++ b/resources/assets/js/components/TextHeatmap/TextHeatmapResponseInputs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div :aria-labelledby="`question-${question.id}-heading`">
     <div
       data-cy="text-heatmap-highlighted-text-container"
       class="form-group text-heatmap-highlighted-text-container"

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -19,8 +19,8 @@
         <section class="card">
           <!-- nav tabs -->
           <div class="card-header">
-            <h2>Chime Questions</h2>
-            <ul class="nav nav-tabs card-header-tabs d-flex" role="tablist">
+            <h2 class="visually-hidden">Chime Questions</h2>
+            <ul class="nav nav-tabs card-header-tabs" role="tablist">
               <li class="nav-item" role="none">
                 <a
                   id="open-questions-tab"

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -15,7 +15,7 @@
         {{ error }}
       </div>
       <VueAnnouncer />
-      <main class="participant-page__main container">
+      <div class="container">
         <div class="card">
           <!-- nav tabs -->
           <div class="card-header">
@@ -116,7 +116,7 @@
             </p>
           </div>
         </div>
-      </main>
+      </div>
     </div>
   </DefaultLayout>
 </template>

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -15,33 +15,50 @@
         {{ error }}
       </div>
       <VueAnnouncer />
-      <div class="container">
-        <div class="card">
+      <div class="container" role="none">
+        <section class="card">
           <!-- nav tabs -->
           <div class="card-header">
-            <ul class="nav nav-tabs card-header-tabs">
-              <li class="nav-item">
+            <h2>Chime Questions</h2>
+            <ul class="nav nav-tabs card-header-tabs d-flex" role="tablist">
+              <li class="nav-item" role="none">
                 <a
+                  id="open-questions-tab"
                   class="nav-link active"
                   data-toggle="tab"
-                  href="#currentQuestions"
-                  >Open Questions</a
+                  type="button"
+                  role="tab"
+                  aria-controls="open-questions"
+                  aria-selected="true"
+                  href="#open-questions"
                 >
+                  Open Questions
+                </a>
               </li>
-              <li class="nav-item">
-                <a class="nav-link" data-toggle="tab" href="#pastQuestions"
-                  >Answered Questions</a
+              <li class="nav-item" role="none">
+                <a
+                  id="answered-questions-tab"
+                  class="nav-link"
+                  data-toggle="tab"
+                  type="button"
+                  role="tab"
+                  aria-controls="answered-questions"
+                  aria-selected="false"
+                  href="#answered-questions"
                 >
+                  Answered Questions
+                </a>
               </li>
             </ul>
           </div>
 
           <div class="tab-content">
-            <!-- openQuestions -->
             <div
-              id="currentQuestions"
+              id="open-questions"
               class="tab-pane container active"
               aria-live="polite"
+              role="tabpanel"
+              aria-labelledby="open-questions-tab"
             >
               <div v-if="ltiLaunchWarning">
                 <h1 class="text-center">
@@ -68,13 +85,13 @@
                 </p>
               </div>
               <template v-else>
-                <div
+                <article
                   v-if="filteredSession.length < 1"
                   key="none"
                   class="text-center"
                 >
-                  <h1>No Open Questions</h1>
-                </div>
+                  <h3>No Open Questions</h3>
+                </article>
                 <TransitionGroup v-if="filteredSession.length > 0" name="fade">
                   <ParticipantPrompt
                     v-for="s in filteredSession"
@@ -87,9 +104,12 @@
                 </TransitionGroup>
               </template>
             </div>
-
-            <!-- answered Questions -->
-            <div id="pastQuestions" class="tab-pane container">
+            <div
+              id="answered-questions"
+              class="tab-pane container"
+              role="tabpanel"
+              aria-labelledby="answered-questions-tab"
+            >
               <div v-if="responses.length < 1" class="text-center">
                 <h1>No Answered Questions</h1>
               </div>
@@ -115,7 +135,7 @@
               </small>
             </p>
           </div>
-        </div>
+        </section>
       </div>
     </div>
   </DefaultLayout>

--- a/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <article
     v-if="question.question_info.question_type"
     class="participant-prompt"
     :class="{
@@ -9,11 +9,17 @@
     }"
   >
     <div class="prompt-question-container">
-      <header class="prompt-header">
+      <div class="prompt-status">
         {{ saveStatus || questionTypeString }}
-      </header>
+      </div>
 
-      <div class="question-text" v-html="question.text" />
+      <div
+        :id="`question-${question.id}-heading`"
+        role="heading"
+        aria-level="3"
+      >
+        <div class="question-text" v-html="question.text" />
+      </div>
     </div>
 
     <div class="prompt-response-area">
@@ -45,7 +51,7 @@
       data-cy="show-folder-to-participants"
       ><strong>Folder</strong>: {{ session.question.folder.name }}
     </small>
-  </div>
+  </article>
 </template>
 
 <script>
@@ -224,7 +230,7 @@ export default {
   background: var(--red);
 }
 
-.prompt-header {
+.prompt-status {
   line-height: 1;
   position: relative;
   text-transform: uppercase;
@@ -236,13 +242,13 @@ export default {
   margin-bottom: 0.5rem;
 }
 
-.save-succeeded .prompt-header {
+.save-succeeded .prompt-status {
   color: #008d22;
 }
-.is-saving .prompt-header {
+.is-saving .prompt-status {
   color: var(--gold);
 }
-.save-failed .prompt-header {
+.save-failed .prompt-status {
   color: var(--red);
 }
 

--- a/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
@@ -2,6 +2,7 @@
   <article
     v-if="question.question_info.question_type"
     class="participant-prompt"
+    :aria-label="`${questionTypeString} Question`"
     :class="{
       'save-succeeded': hasPreviouslySaved || saveSucceeded,
       'save-failed': saveFailed,

--- a/resources/assets/js/views/ParticipantPage/ParticipantResponse.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantResponse.vue
@@ -1,7 +1,9 @@
 <template>
-  <div class="row responseContainer">
+  <article class="row responseContainer">
     <div v-if="response.session && response.session.question" class="col-12">
-      <p class="questionText" v-html="response.session.question.text"></p>
+      <div role="heading" aria-level="3">
+        <div class="questionText" v-html="response.session.question.text" />
+      </div>
       <component
         :is="response.session.question.question_info.question_type"
         :question="response.session.question"
@@ -29,7 +31,7 @@
       </small>
       <hr />
     </div>
-  </div>
+  </article>
 </template>
 
 <script>


### PR DESCRIPTION
This improves accessibility headings and labels of question prompts for users using screen readers.

- The question container is given a heading (visually hidden): `ChimeIn Questions`
- The "open question" and "answered" tabs at the top are given `tab` roles.
- question containers have been changed from generic divs to `articles`. The container is given a label of the question type. e.g. `Multiple Choice Question`, similar to how the question appears to sighted users.
- Each question prompt is given a role of heading (level 3). This is based on feedback that most users prefer to navigate a page using headings.
- Each input is associated to the question prompt using `aria-labelledby`, so that the input label is announced to users.
- Range input includes `min` and `max` attributes, to make these more accessible to screen reader users.

Closes #384
Closes #385 
Closes #386

