### PR TITLE
update chart.js to 3.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@vue-a11y/announcer": "^3.1.5",
     "axios": "^0.27",
     "bootstrap": "^4.6.0",
-    "chart.js": "^3.8.2",
+    "chart.js": "^3.9.1",
     "chartjs-chart-wordcloud": "^3.7.1",
     "color": "^4.2.3",
     "compromise": "^11.14.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2997,10 +2997,10 @@ charenc@0.0.2:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
-chart.js@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.8.2.tgz#e3ebb88f7072780eec4183a788a990f4a58ba7a1"
-  integrity sha512-7rqSlHWMUKFyBDOJvmFGW2lxULtcwaPLegDjX/Nu5j6QybY+GCiQkEY+6cqHw62S5tcwXMD8Y+H5OBGoR7d+ZQ==
+chart.js@^3.9.1:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.9.1.tgz#3abf2c775169c4c71217a107163ac708515924b8"
+  integrity sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w==
 
 chartjs-chart-wordcloud@^3.7.1:
   version "3.7.1"


### PR DESCRIPTION
This updates chart.js to the latest release.

building can fail with the previous version of Chart.js:
```
ERROR in ./node_modules/chart.js/helpers/helpers.mjs 1:0-36
Module not found: Error: Can't resolve '../dist/helpers.esm' in '/home/runner/work/ChimeIn2.0/ChimeIn2.0/node_modules/chart.js/helpers'
Did you mean 'helpers.esm.js'?
BREAKING CHANGE: The request '../dist/helpers.esm' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

See: https://github.com/chartjs/Chart.js/pull/10552
