### PR TITLE
Add alt text and image resizing in the question editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.5",
+    "@umn-latis/quill-better-image-module": "^0.1.0",
     "@vue-a11y/announcer": "^3.1.5",
     "axios": "^0.27",
     "bootstrap": "^4.6.0",

--- a/resources/assets/js/hooks/useQuill.js
+++ b/resources/assets/js/hooks/useQuill.js
@@ -1,18 +1,18 @@
 import { onMounted, ref } from "vue";
 import Quill from "quill";
-// import BlotFormatter from "quill-blot-formatter";
 import QuillImageUploader from "quill-image-uploader";
+import QuillBetterImage from "@umn-latis/quill-better-image-module";
 import mergeDeepRight from "ramda/es/mergeDeepRight.js";
 import "quill/dist/quill.snow.css";
 
 const defaultModules = [
-  // {
-  //   name: "blotFormatter",
-  //   module: BlotFormatter,
-  // },
   {
     name: "imageUploader",
     module: QuillImageUploader,
+  },
+  {
+    name: "betterImage",
+    module: QuillBetterImage,
   },
 ];
 
@@ -49,6 +49,7 @@ export default function useQuill({
           );
         },
       },
+      betterImage: {},
     },
     theme: "snow",
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1808,6 +1808,13 @@
     "@typescript-eslint/types" "5.25.0"
     eslint-visitor-keys "^3.3.0"
 
+"@umn-latis/quill-better-image-module@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@umn-latis/quill-better-image-module/-/quill-better-image-module-0.1.0.tgz#1ee9f5716d87150e1d7c3c36cf7fbb85e6e8369c"
+  integrity sha512-PHo5y31TgfWArLPjBw6f1gkT9+ziDr/8y/qtnCIsl098V4BsHF9tQINFzAGLpQk1JPK2IcHTob1PYH1621izIg==
+  dependencies:
+    lodash "^4.17.21"
+
 "@volar/code-gen@0.34.13":
   version "0.34.13"
   resolved "https://registry.yarnpkg.com/@volar/code-gen/-/code-gen-0.34.13.tgz#39c278777d33a06c6806f1701df3143441c71e16"


### PR DESCRIPTION
This enhances image editing functionality within the quill editor, so that users can resize images or add alt attributes:
- Closes https://github.com/UMN-LATIS/ChimeIn2.0/issues/368
- Closes https://github.com/UMN-LATIS/ChimeIn2.0/issues/186

The functionality is added by [@umn-latis/quill-better-image-module](https://github.com/UMN-LATIS/quill-better-image-module), which is based on a [good, but abandoned module for resizing images](https://github.com/kensnyder/quill-image-resize-module). Our fork fixes a few outstanding issues, changes the bundler from old webpack 2 to vite, and adds support for alt text.

Short demo:
![Screen Recording 2022-08-11 at 12 43 09 PM](https://user-images.githubusercontent.com/980170/184200903-3da78f93-1dcb-4d69-894a-884b6dc3fb72.gif)

Testable version on: <https://cla-chimein-dev.cla.umn.edu/>