### PR TITLE
explicitly cast values as booleans

### DIFF
--- a/app/Chime.php
+++ b/app/Chime.php
@@ -19,6 +19,13 @@ class Chime extends Model
         'join_instructions' => true,
     ];
     
+    protected $casts = [
+        'require_login' => 'boolean',
+        'students_can_view' => 'boolean',
+        'join_instructions' => 'boolean',
+        'show_folder_title_to_participants' => 'boolean'
+    ];
+
     protected $dates = ['deleted_at'];
     protected $cascadeDeletes = ['folders'];
 

--- a/app/Question.php
+++ b/app/Question.php
@@ -11,9 +11,11 @@ class Question extends Model
 
     protected $fillable = ['text', 'order', 'question_info', 'anonymous', 'folder_id', "allow_multiple"];
     protected $dates = ['deleted_at'];
-     
+
     protected $casts = [
         'question_info' => 'array',
+        'anonymous' => 'boolean',
+        'allow_multiple' => 'boolean'
     ];
     public function folder() {
         return $this->belongsTo(Folder::class);

--- a/app/User.php
+++ b/app/User.php
@@ -32,6 +32,11 @@ class User extends Authenticatable
         'password', 'remember_token',
     ];
 
+    protected $casts = [
+        'guest_user' => 'boolean',
+        'global_admin' => 'boolean',
+    ];
+
     public function chimes() {
         return $this->belongsToMany(Chime::class)
             ->withPivot('permission_number')

--- a/cypress/integration/ui/question.test.js
+++ b/cypress/integration/ui/question.test.js
@@ -198,6 +198,42 @@ describe("question", () => {
   });
 
   it("changes the folder");
+
+  it("persists question settings changes on save", () => {
+    let testChime;
+    let testFolder;
+    api
+      .createChime({ name: "Test Chime" })
+      .then((chime) => {
+        testChime = chime;
+        return api.createFolder({ name: "Test Folder", chimeId: chime.id });
+      })
+      .then((folder) => {
+        testFolder = folder;
+      })
+      .then(() => {
+        cy.visit(`/chime/${testChime.id}/folder/${testFolder.id}`);
+
+        // create the question
+        cy.get("[data-cy=new-question-button]").click();
+        cy.get("[data-cy=question-type]").type("Free Response{enter}");
+        cy.get("[data-cy=question-editor]").type("Free response question?");
+
+        // try toggling a question option and save
+        cy.get('[data-cy="allow-multiple-responses-checkbox"]').click();
+        cy.contains("Save").click();
+        cy.wait("@apiCreateQuestion");
+
+        // open the question
+        cy.get('[data-cy="edit-question-button"]').click();
+
+        // check that allow multiple is still checked
+        cy.get('[data-cy="allow-multiple-responses-checkbox"]').should(
+          "be.checked"
+        );
+      });
+  });
+
   it("allows multiple responses", () => {
     let testChime;
     let testFolder;


### PR DESCRIPTION
In the current version of VueJS, checkbox inputs using `v-model` no longer coerce a 1 and 0 to true/false values. 

This PR explicitly casts some model values to booleans, and adds a test that checkbox changes persist after saving.

Closes #415 .

@cmcfadden – I just saw your comment on the other issue. We can discuss tomorrow if other approaches might be better.