### PR TITLE
Fix heatmap question circle rendering on answered questions tab

### DIFF
--- a/cypress/integration/ui/question.test.js
+++ b/cypress/integration/ui/question.test.js
@@ -945,6 +945,49 @@ describe("question", () => {
           );
         })
         .then(() => {
+          // check the circle location shows up in the correct place
+          cy.get("#open-questions [data-cy=image-heatmap-click-spot]").as(
+            "click-spot"
+          );
+
+          cy.get("@click-spot")
+            .should("have.css", "top")
+            .should((topVal) => {
+              expect(topVal).to.include("px");
+              expect(Number.parseInt(topVal, 10)).to.be.within(99, 101);
+            });
+
+          cy.get("@click-spot")
+            .should("have.css", "left")
+            .should((leftVal) => {
+              expect(leftVal).to.include("px");
+              expect(Number.parseInt(leftVal, 10)).to.be.within(49, 51);
+            });
+        })
+        .then(() => {
+          // check the answered questions tab
+          cy.contains("Answered Questions").click();
+
+          // check the circle location shows up in the correct place
+          cy.get("#answered-questions [data-cy=image-heatmap-click-spot]").as(
+            "answered-click-spot"
+          );
+
+          cy.get("@answered-click-spot")
+            .should("have.css", "top")
+            .should((topVal) => {
+              expect(topVal).to.include("px");
+              expect(Number.parseInt(topVal, 10)).to.be.within(99, 101);
+            });
+
+          cy.get("@answered-click-spot")
+            .should("have.css", "left")
+            .should((leftVal) => {
+              expect(leftVal).to.include("px");
+              expect(Number.parseInt(leftVal, 10)).to.be.within(49, 51);
+            });
+        })
+        .then(() => {
           // login as faculty
           cy.login("faculty");
           cy.visit(`/chime/${testChime.id}/folder/${testFolder.id}`);

--- a/resources/assets/js/components/ImageHeatmapResponse/ImageHeatmapResponseInputs.vue
+++ b/resources/assets/js/components/ImageHeatmapResponse/ImageHeatmapResponseInputs.vue
@@ -3,6 +3,7 @@
     <div class="image-heatmap-response__image-container">
       <div
         v-if="image_coordinates && targetImageLoaded"
+        data-cy="image-heatmap-click-spot"
         class="clickPointer"
         :style="{
           top: image_coordinates.coordinate_y + 'px',


### PR DESCRIPTION
This PR indirectly resolves an issue #320, where a heatmap response incorrectly renders the click spot at 0,0 on an inactive tab. (e.g. the "answered questions" tab when the page is first loaded, or the "open questions" if a user clicks on the "answered questions" and then resizes the window).

The issue is that `targetImage.clientWidth` is calculated as 0 when a tab pane isn't display.

@cmcfadden and I discussed a few ways of resolving the issue:
1. recalculate the circle coordinates when an image becomes visible perhaps using [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API),
2. don't mount question responses on the participant page until the tab becomes active. Then, once the tab is active, the correct clientWidth will be calculated when the component mounts.

This PR goes with option 2:
- removed using bootstrap's `data-toggle` js and used our own tab toggling directly in vue
- added a `v-if` to each tab panel, so that it wouldn't render unless active
- wrapped tab panels in a `<Transition>` to improve the repaint flash (this could probably be better, but it does the job for now)

closes #320 