### PR TITLE
Add breadcrumbs to make it easier to tell the Chime name while in folder

### DIFF
--- a/cypress/integration/ui/happyPath.test.js
+++ b/cypress/integration/ui/happyPath.test.js
@@ -17,7 +17,7 @@ describe("happy path", () => {
     cy.get("#joinInstructions").check();
     cy.get("[data-cy=create-chime-button]").click();
     cy.url().should("match", /chime\/[0-9]+$/);
-    cy.get("h1").should("contain", "Test Chime");
+    cy.get("[data-cy=chime-name]").should("contain", "Test Chime");
 
     // create a folder
     cy.get("#createFolder").type("Test Folder 1");
@@ -26,7 +26,7 @@ describe("happy path", () => {
     // go into the folder
     cy.get("[data-cy=folder-card]").contains("Test Folder 1").click();
     cy.url().should("match", /chime\/[0-9]+\/folder\/[0-9]+$/);
-    cy.get("h1").should("contain", "Test Folder 1");
+    cy.get("[data-cy=folder-name]").should("contain", "Test Folder 1");
 
     // create a question
     cy.get("[data-cy=new-question-button]").click();

--- a/resources/assets/js/components/BreadcrumbNav.vue
+++ b/resources/assets/js/components/BreadcrumbNav.vue
@@ -1,0 +1,53 @@
+<template>
+  <nav class="breadcrumb-nav" aria-label="Breadcrumb Navigation">
+    <ol class="breadcrumb-nav__list">
+      <li v-for="(link, i) in links" :key="i" class="breadcrumb-nav__list-item">
+        <component
+          :is="link.to ? RouterLink : 'span'"
+          :to="link.to"
+          class="breadcrumb-nav__list-item-content"
+        >
+          {{ link.name }}
+        </component>
+      </li>
+    </ol>
+  </nav>
+</template>
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+
+interface NavLink {
+  name: string;
+  to?: string;
+}
+
+defineProps<{
+  links: NavLink[];
+}>();
+</script>
+<style scoped>
+.breadcrumb-nav {
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  --gap-size: 0.5rem;
+}
+
+.breadcrumb-nav__list {
+  list-style: none;
+  display: flex;
+  gap: var(--gap-size);
+  padding: 0;
+  flex-wrap: wrap;
+}
+
+.breadcrumb-nav__list-item {
+  display: flex;
+  align-items: center;
+}
+
+.breadcrumb-nav__list-item:not(:last-child):after {
+  content: "/";
+  display: block;
+  margin-left: var(--gap-size);
+}
+</style>

--- a/resources/assets/js/views/ChimePage/ChimePage.vue
+++ b/resources/assets/js/views/ChimePage/ChimePage.vue
@@ -6,6 +6,9 @@
     <div class="chime container-fluid mt-4">
       <ErrorDialog />
       <div>
+        <BreadcrumbNav
+          :links="[{ name: 'Home', to: '/' }, { name: chime.name }]"
+        />
         <header class="chime__header">
           <Chip
             v-if="isCanvasChime"
@@ -126,6 +129,7 @@ import {
 import DefaultLayout from "../../layouts/DefaultLayout.vue";
 import * as api from "../../common/api";
 import Back from "../../components/Back.vue";
+import BreadcrumbNav from "../../components/BreadcrumbNav.vue";
 
 export default {
   components: {
@@ -140,6 +144,7 @@ export default {
     DefaultLayout,
     Back,
     JoinPanel,
+    BreadcrumbNav,
   },
   props: {
     user: {

--- a/resources/assets/js/views/ChimePage/ChimePage.vue
+++ b/resources/assets/js/views/ChimePage/ChimePage.vue
@@ -6,9 +6,6 @@
     <div class="chime container-fluid mt-4">
       <ErrorDialog />
       <div>
-        <BreadcrumbNav
-          :links="[{ name: 'Home', to: '/' }, { name: chime.name }]"
-        />
         <header class="chime__header">
           <Chip
             v-if="isCanvasChime"
@@ -129,7 +126,6 @@ import {
 import DefaultLayout from "../../layouts/DefaultLayout.vue";
 import * as api from "../../common/api";
 import Back from "../../components/Back.vue";
-import BreadcrumbNav from "../../components/BreadcrumbNav.vue";
 
 export default {
   components: {
@@ -144,7 +140,6 @@ export default {
     DefaultLayout,
     Back,
     JoinPanel,
-    BreadcrumbNav,
   },
   props: {
     user: {
@@ -312,7 +307,7 @@ export default {
   display: none;
   margin-top: 1rem;
   padding: 2rem;
-  background-color: #fafafa;
+  background-color: #fff;
   line-height: 1.5;
   border-radius: 0.25rem;
   overflow: auto;

--- a/resources/assets/js/views/ChimePage/ChimePage.vue
+++ b/resources/assets/js/views/ChimePage/ChimePage.vue
@@ -304,6 +304,7 @@ export default {
   align-items: center;
   padding: 0.5rem 1rem;
   border-radius: 0;
+  gap: 0.25rem;
 }
 
 .chime-page-header__button-group .btn:hover {
@@ -355,7 +356,8 @@ export default {
 
 @media (max-width: 768px) {
   .chime__header-container {
-    display: block;
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .chime__control-buttons {

--- a/resources/assets/js/views/ChimePage/ChimePage.vue
+++ b/resources/assets/js/views/ChimePage/ChimePage.vue
@@ -21,16 +21,12 @@
               {{ chime.name }}
             </h1>
             <div
-              class="chime__control-buttons btn-group"
+              class="chime-page-header__button-group"
               role="group"
               aria-label="Chime Controls"
-              :class="{
-                'chime__control-buttons--is-active':
-                  showSettings || exportPanel,
-              }"
             >
               <button
-                class="chime__control-button btn btn-outline-secondary align-items-center d-flex"
+                class="btn"
                 :class="{ 'btn--is-active': showSettings }"
                 data-cy="toggle-chime-settings-panel"
                 @click="toggle('showSettings', { setToFalse: ['exportPanel'] })"
@@ -39,7 +35,7 @@
               </button>
 
               <button
-                class="chime__control-button btn btn-outline-secondary align-items-center d-flex"
+                class="btn"
                 :class="{ 'btn--is-active': exportPanel }"
                 data-cy="toggle-chime-export-panel"
                 @click="toggle('exportPanel', { setToFalse: ['showSettings'] })"
@@ -50,17 +46,19 @@
           </div>
           <div
             v-if="isReady"
-            class="chime__settings-panel"
+            class="chime-settings-panel"
             :class="{
-              'chime__settings-panel--isOpen': showSettings || exportPanel,
+              'chime-settings-panel--isOpen': showSettings || exportPanel,
             }"
           >
-            <ChimeManagement
-              v-if="showSettings"
-              :chime="chime"
-              @update:chime="handleChimeUpdate"
-            />
-            <ChimeExport v-if="exportPanel" :chime="chime" />
+            <div class="chime-settings-panel__container">
+              <ChimeManagement
+                v-if="showSettings"
+                :chime="chime"
+                @update:chime="handleChimeUpdate"
+              />
+              <ChimeExport v-if="exportPanel" :chime="chime" />
+            </div>
           </div>
         </header>
 
@@ -289,8 +287,28 @@ export default {
   margin: 0;
   margin-right: 0.5rem;
 }
-.chime__control-buttons {
+
+.chime-page-header__button-group {
+  display: flex;
+  flex-wrap: wrap;
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  border-radius: 0.25rem;
+  overflow: hidden;
+  background: #fff;
   flex-shrink: 0;
+}
+
+.chime-page-header__button-group .btn {
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-radius: 0;
+}
+
+.chime-page-header__button-group .btn:hover {
+  background: #f3f3f3;
+  color: #111;
 }
 
 .chime__control-buttons .material-icons {
@@ -298,12 +316,22 @@ export default {
   margin-right: 0.25rem;
 }
 
-.chime__control-buttons .btn--is-active {
-  background: var(--gray-dark);
+.btn.btn--is-active {
+  background: #111;
   color: #fff;
 }
 
-.chime__settings-panel {
+.btn.btn--is-active:hover {
+  background: #333;
+  color: #fff;
+}
+
+.btn:focus-visible {
+  border: 2px solid #007bff;
+  border-radius: 0.25rem;
+}
+
+.chime-settings-panel {
   display: none;
   margin-top: 1rem;
   padding: 2rem;
@@ -311,10 +339,14 @@ export default {
   line-height: 1.5;
   border-radius: 0.25rem;
   overflow: auto;
-  border: 1px solid var(--gray-light);
+  box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
-.chime__settings-panel--isOpen {
+.chime-settings-panel--isOpen {
   display: block;
+}
+
+.chime-settings-panel__container {
+  max-width: 40rem;
 }
 
 .chime__create-folder {

--- a/resources/assets/js/views/ChimePage/ChimePage.vue
+++ b/resources/assets/js/views/ChimePage/ChimePage.vue
@@ -17,7 +17,7 @@
             Canvas
           </Chip>
           <div class="chime__header-container">
-            <h1 class="chime__name">
+            <h1 class="chime__name" data-cy="chime-name">
               {{ chime.name }}
             </h1>
             <div

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -185,7 +185,7 @@
           <div>
             <button
               data-cy="new-question-button"
-              class="btn btn-outline-primary align-items-center d-flex"
+              class="btn btn-outline-primary align-items-center d-flex my-2"
               @click="showModal = true"
             >
               <i class="material-icons pointer">add</i> Add Question

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -35,7 +35,9 @@
                 {{ chime.name }}
               </RouterLink>
             </p>
-            <h2 class="folder-page-header__folder-name">{{ folder.name }}</h2>
+            <h2 class="folder-page-header__folder-name" data-cy="folder-name">
+              {{ folder.name }}
+            </h2>
           </div>
           <div class="folder-page-header__controls">
             <div

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -19,43 +19,34 @@
       </div>
       <Spinner v-if="!isPageReady" />
       <div v-if="isPageReady && !isParticipantView">
-        <BreadcrumbNav
-          :links="[
-            { name: 'Home', to: '/' },
-            { name: chime.name, to: `/chime/${chime.id}` },
-            { name: folder.name },
-          ]"
-          class="my-4"
-        />
-        <div class="row mt-4">
-          <div class="col-md-4 align-items-center d-flex">
-            <h1 class="h4">{{ folder.name }}</h1>
+        <header class="folder-page-header">
+          <div class="folder-page-header__folder-name-group">
+            <p class="folder-page-header__chime-name">
+              <RouterLink :to="`/chime/${chime.id}`">
+                {{ chime.name }}
+              </RouterLink>
+            </p>
+            <h2 class="folder-page-header__folder-name">{{ folder.name }}</h2>
           </div>
-          <div class="col-md-8 col-sm-12">
+          <div class="folder-page-header__controls">
             <div
-              class="btn-group float-right"
-              style="flex-wrap: wrap"
+              class="folder-page-header__button-group"
               role="group"
               aria-label="Folder Controls"
             >
               <button
-                class="btn btn-sm btn-outline-secondary align-items-center d-flex"
+                class="btn folder-settings-btn"
+                :class="{
+                  'folder-settings-btn--is-active': show_edit_folder,
+                }"
                 @click="show_edit_folder = !show_edit_folder"
               >
                 <i class="material-icons pointer">edit</i> Folder Settings
               </button>
-              <button
-                dusk="open-all-button"
-                class="btn btn-sm btn-outline-secondary align-items-center d-flex"
-                @click="openAll"
-              >
+              <button class="btn" @click="openAll">
                 <i class="material-icons pointer">visibility</i> Open All
               </button>
-              <button
-                dusk="close-all-button"
-                class="btn btn-sm btn-outline-secondary align-items-center d-flex"
-                @click="closeAll"
-              >
+              <button class="btn" @click="closeAll">
                 <i class="material-icons pointer">visibility_off</i> Close All
               </button>
               <router-link
@@ -67,7 +58,7 @@
                     callbackUrl: $route.path,
                   },
                 }"
-                class="btn btn-sm btn-outline-secondary align-items-center d-flex"
+                class="btn"
               >
                 <i class="material-icons">preview</i>
                 Participant View
@@ -77,108 +68,111 @@
                   name: 'present',
                   params: { chimeId: chimeId, folderId: folderId },
                 }"
-                class="btn btn-sm btn-outline-secondary align-items-center d-flex"
+                class="btn"
               >
                 <i class="material-icons">play_arrow</i>
                 Present
               </router-link>
             </div>
           </div>
-        </div>
-        <div v-if="show_edit_folder && folder" class="ml-4 mt-2">
-          <div class="row">
-            <div class="col-12">
-              <div class="input-group mb-3">
-                <input
-                  :value="folder.name"
-                  type="text"
-                  class="form-control"
-                  @input="handleFolderNameInput"
-                />
+        </header>
+        <div v-if="show_edit_folder && folder" class="folder-settings-panel">
+          <div class="folder-settings-panel__container">
+            <h3 class="folder-settings-panel__heading">Folder Settings</h3>
+            <div class="row">
+              <div class="col-12">
+                <div class="input-group mb-3">
+                  <input
+                    :value="folder.name"
+                    type="text"
+                    class="form-control"
+                    @input="handleFolderNameInput"
+                  />
 
-                <div class="input-group-append">
-                  <button
-                    class="btn btn-outline-primary align-items-center d-flex"
-                    @click="edit_folder"
-                  >
-                    <span class="material-icons pointer">save</span> Save
-                  </button>
+                  <div class="input-group-append">
+                    <button
+                      class="btn btn-outline-primary align-items-center d-flex"
+                      @click="edit_folder"
+                    >
+                      <span class="material-icons pointer">save</span> Save
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
-            <div class="ml-auto col-12 btn-toolbar justify-content-end">
-              <button
-                v-if="folder.resource_link_pk > 0 || folder.lti_lineitem"
-                class="mr-2 btn btn-success btn-sm align-items-center d-flex"
-                @click="sync"
-              >
-                Force Sync with Canvas
-                <span v-if="synced" class="material-icons md-18"
-                  >check_circle</span
+              <div class="ml-auto col-12 btn-toolbar justify-content-end">
+                <button
+                  v-if="folder.resource_link_pk > 0 || folder.lti_lineitem"
+                  class="mr-2 btn btn-success btn-sm align-items-center d-flex"
+                  @click="sync"
                 >
-              </button>
-              <button
-                class="mr-2 btn btn-warning btn-sm align-items-center d-flex"
-                @click="reset"
-              >
-                Reset Folder
-              </button>
-              <button
-                class="btn btn-sm btn-danger align-items-center d-flex"
-                @click="delete_folder"
-              >
-                Delete Folder <i class="material-icons pointer md-18">delete</i>
-              </button>
-            </div>
-          </div>
-
-          <hr />
-          <fieldset class="form-group border p-2">
-            <legend class="col-form-label w-auto">Import Questions</legend>
-            <div class="row">
-              <div class="col-sm-12">
-                <div class="form-group">
-                  <label for="chime_select">Select a Chime:</label>
-                  <select
-                    id="chime_select"
-                    v-model="selected_chime"
-                    class="form-control"
-                    @change="update_folders"
+                  Force Sync with Canvas
+                  <span v-if="synced" class="material-icons md-18"
+                    >check_circle</span
                   >
-                    <option disabled>Select a Chime</option>
-                    <option
-                      v-for="c in existing_chimes"
-                      :key="c.id"
-                      :value="c.id"
-                    >
-                      {{ c.name }}
-                    </option>
-                  </select>
-                </div>
-
-                <div class="form-group">
-                  <label for="folder_select">Select a Folder:</label>
-                  <select
-                    id="folder_select"
-                    v-model="selected_folder"
-                    class="form-control"
-                  >
-                    <option disabled>Select a Folder</option>
-                    <option
-                      v-for="f in existing_folders"
-                      :key="f.id"
-                      :value="f.id"
-                    >
-                      {{ f.name }}
-                    </option>
-                  </select>
-                </div>
-                <button class="btn btn-primary" @click="do_import">
-                  Import
+                </button>
+                <button
+                  class="mr-2 btn btn-warning btn-sm align-items-center d-flex"
+                  @click="reset"
+                >
+                  Reset Folder
+                </button>
+                <button
+                  class="btn btn-sm btn-danger align-items-center d-flex"
+                  @click="delete_folder"
+                >
+                  Delete Folder
+                  <i class="material-icons pointer md-18">delete</i>
                 </button>
               </div>
             </div>
-          </fieldset>
+
+            <fieldset class="form-group border p-2">
+              <legend class="col-form-label w-auto">Import Questions</legend>
+              <div class="row">
+                <div class="col-sm-12">
+                  <div class="form-group">
+                    <label for="chime_select">Select a Chime:</label>
+                    <select
+                      id="chime_select"
+                      v-model="selected_chime"
+                      class="form-control"
+                      @change="update_folders"
+                    >
+                      <option disabled>Select a Chime</option>
+                      <option
+                        v-for="c in existing_chimes"
+                        :key="c.id"
+                        :value="c.id"
+                      >
+                        {{ c.name }}
+                      </option>
+                    </select>
+                  </div>
+
+                  <div class="form-group">
+                    <label for="folder_select">Select a Folder:</label>
+                    <select
+                      id="folder_select"
+                      v-model="selected_folder"
+                      class="form-control"
+                    >
+                      <option disabled>Select a Folder</option>
+                      <option
+                        v-for="f in existing_folders"
+                        :key="f.id"
+                        :value="f.id"
+                      >
+                        {{ f.name }}
+                      </option>
+                    </select>
+                  </div>
+                  <button class="btn btn-primary" @click="do_import">
+                    Import
+                  </button>
+                </div>
+              </div>
+            </fieldset>
+          </div>
         </div>
 
         <div class="border-top mt-3 pt-3 folder-page__main">
@@ -249,7 +243,6 @@ import useQuestionListener from "../../hooks/useQuestionListener";
 import { useStore } from "vuex";
 import DefaultLayout from "../../layouts/DefaultLayout.vue";
 import JoinPanel from "../../components/JoinPanel.vue";
-import BreadcrumbNav from "../../components/BreadcrumbNav.vue";
 import {
   getChimes,
   getOpenSessionsWithinChime,
@@ -492,5 +485,84 @@ ul li {
     gap: 1.5rem;
     align-items: flex-start;
   }
+}
+
+.folder-page-header {
+  /* border: 1px solid red; */
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-top: 1rem;
+}
+.folder-page-header__folder-name-group {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.folder-page-header__folder-name,
+.folder-page-header__chime-name {
+  margin: 0;
+}
+
+.folder-page-header__chime-name {
+  text-transform: uppercase;
+  font-size: 0.8rem;
+}
+
+.folder-page-header__chime-name a {
+  color: var(--dark-gray);
+}
+
+.folder-page-header__button-group {
+  display: flex;
+  flex-wrap: wrap;
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  border-radius: 0.25rem;
+  overflow: hidden;
+  background: #fff;
+}
+
+.folder-page-header__button-group .btn {
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-radius: 0;
+}
+
+.folder-page-header__button-group .btn:hover {
+  background: #f3f3f3;
+  color: #111;
+}
+
+.folder-settings-panel {
+  margin-top: 1rem;
+  padding: 2rem;
+  background-color: #fff;
+  line-height: 1.5;
+  border-radius: 0.25rem;
+  border: 1px solid var(--gray-light);
+}
+
+.folder-settings-panel__heading {
+  font-size: 1.25rem;
+}
+
+.folder-settings-panel__container {
+  max-width: 40rem;
+}
+
+.folder-settings-btn.folder-settings-btn--is-active {
+  background: #111;
+  color: #fff;
+}
+
+.folder-settings-btn.folder-settings-btn--is-active:hover {
+  background: #333;
+  color: #fff;
 }
 </style>

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -545,7 +545,7 @@ ul li {
   background-color: #fff;
   line-height: 1.5;
   border-radius: 0.25rem;
-  border: 1px solid var(--gray-light);
+  box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
 .folder-settings-panel__heading {

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -7,15 +7,24 @@
     <div class="container-fluid">
       <div
         v-if="!hideOpenAlert && otherFolderSessions.length > 0"
-        class="alert alert-warning"
+        class="alert alert-warning d-flex my-4 align-items-center justify-content-between"
         role="alert"
       >
-        You have {{ otherFolderSessions.length }}
-        {{ pluralize("question", otherFolderSessions.length) }} open outside
-        this folder. Would you like to
-        <a class="pointer" href="" @click.prevent="closeOthers"
-          >close {{ otherFolderSessions.length == 1 ? "it" : "them" }}</a
-        >?<a class="float-right pointer" @click="hideOpenAlert = true">X</a>
+        <p class="flex-1 m-0">
+          You have {{ otherFolderSessions.length }}
+          {{ pluralize("question", otherFolderSessions.length) }} open outside
+          this folder. Would you like to
+          <a class="pointer" href="#!" @click.prevent="closeOthers"
+            >close {{ otherFolderSessions.length == 1 ? "it" : "them" }}</a
+          >?
+        </p>
+
+        <button
+          class="pointer btn d-flex align-items-center justify-content-center p-2 m-0"
+          @click="hideOpenAlert = true"
+        >
+          <span class="material-icons">close</span>
+        </button>
       </div>
       <Spinner v-if="!isPageReady" />
       <div v-if="isPageReady && !isParticipantView">
@@ -475,7 +484,6 @@ ul li {
 }
 .material-icons {
   font-size: 1.25rem;
-  margin-right: 0.25rem;
 }
 
 @media (min-width: 50rem) {
@@ -493,11 +501,10 @@ ul li {
   flex-wrap: wrap;
   gap: 1rem;
   justify-content: space-between;
-  align-items: flex-end;
-  margin-top: 1rem;
+  align-items: center;
+  margin: 2rem 0;
 }
 .folder-page-header__folder-name-group {
-  margin-top: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -532,6 +539,7 @@ ul li {
   align-items: center;
   padding: 0.5rem 1rem;
   border-radius: 0;
+  gap: 0.25rem;
 }
 
 .folder-page-header__button-group .btn:hover {

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -19,6 +19,14 @@
       </div>
       <Spinner v-if="!isPageReady" />
       <div v-if="isPageReady && !isParticipantView">
+        <BreadcrumbNav
+          :links="[
+            { name: 'Home', to: '/' },
+            { name: chime.name, to: `/chime/${chime.id}` },
+            { name: folder.name },
+          ]"
+          class="my-4"
+        />
         <div class="row mt-4">
           <div class="col-md-4 align-items-center d-flex">
             <h1 class="h4">{{ folder.name }}</h1>
@@ -241,6 +249,7 @@ import useQuestionListener from "../../hooks/useQuestionListener";
 import { useStore } from "vuex";
 import DefaultLayout from "../../layouts/DefaultLayout.vue";
 import JoinPanel from "../../components/JoinPanel.vue";
+import BreadcrumbNav from "../../components/BreadcrumbNav.vue";
 import {
   getChimes,
   getOpenSessionsWithinChime,


### PR DESCRIPTION
- Adds a breadcrumb component
- Adds breadcrumbs to ChimePage and FolderPage

Breadcrumb component:
<img width="500" alt="Screen Shot 2022-09-15 at 5 30 01 PM" src="https://user-images.githubusercontent.com/980170/190519872-b8eff1ef-55bf-469d-8ab1-a4220873a744.png">

Folder Page with Breadcrumb:
<img width="500" alt="Screen Shot 2022-09-15 at 5 28 05 PM" src="https://user-images.githubusercontent.com/980170/190519896-b2642296-dd9f-42ce-b51f-1fe0b8aaa00d.png">

Design notes:
- Tried it both with and without current page showing as the last item. I thought it was a little better with the current page. Even though there's duplication of text, I thought it added clarity about the Home > Chime > Folder> Question organization that could aid new users.
- Using a basic "/" as a divider. Tried a chevron, but it looked a little strange with the "back" chevron pointing in the opposite direction.

Definitely weakly held opinions though, so let me know what you think.

Fixes #466