### PR TITLE
Fix unclickable app footer buttons 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "resources/assets/cla-vue-template"]
 	path = resources/assets/cla-vue-template
 	url = https://github.com/UMN-LATIS/CLA-vue-template.git
-  branch = main
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "resources/assets/cla-vue-template"]
 	path = resources/assets/cla-vue-template
 	url = https://github.com/UMN-LATIS/CLA-vue-template.git
+  branch = main

--- a/resources/assets/js/layouts/DefaultLayout.vue
+++ b/resources/assets/js/layouts/DefaultLayout.vue
@@ -22,7 +22,7 @@
     <main class="default-layout__main flex-grow-1" v-bind="$attrs">
       <slot> Sorry. Nothing to see here. </slot>
     </main>
-    <AppFooter />
+    <AppFooter class="default-layout__app-footer" />
   </div>
 </template>
 <script setup lang="ts">
@@ -56,5 +56,22 @@ export default {
 }
 .default-layout__main {
   padding-bottom: 4rem;
+}
+
+/* 
+* the app-footer cla component has a negative margin so that it can tuck
+* under the "post-it" component. Since we're not using the post-it component,
+* we need to remove the negative margin to prevent the footer from overlapping
+* the main section.
+*/
+.default-layout__app-footer {
+  margin-top: 0;
+}
+
+/**
+ * decrease app-footer padding to compensate for no negative margin
+ */
+.default-layout__app-footer::v-deep .footer-offset-container {
+  padding-top: 3rem;
 }
 </style>


### PR DESCRIPTION
Updates vue-template-components' AppFooter, which removes the z-index preventing buttons from being clickable. 

Adds some styles to ChimeIn's `<DefaultLayout>` component to remove the negative margin on AppFooter, preventing it from accidentally overlapping the main area.

See: https://github.com/UMN-LATIS/CLA-vue-template/pull/10

Closes #473 