### PR TITLE
fix deprecation of `v-deep`. Change to `:deep()`

### DIFF
--- a/resources/assets/js/layouts/DefaultLayout.vue
+++ b/resources/assets/js/layouts/DefaultLayout.vue
@@ -71,7 +71,7 @@ export default {
 /**
  * decrease app-footer padding to compensate for no negative margin
  */
-.default-layout__app-footer::v-deep .footer-offset-container {
+.default-layout__app-footer:deep(.footer-offset-container) {
   padding-top: 3rem;
 }
 </style>


### PR DESCRIPTION
Changes deprecated `v-deep` to `:deep`.