### PR TITLE
Fix: Slider question not submitting correct value due to min/max

### DIFF
--- a/resources/assets/js/components/SliderResponse/SliderResponseInputs.vue
+++ b/resources/assets/js/components/SliderResponse/SliderResponseInputs.vue
@@ -18,7 +18,7 @@
             data-cy="slider-response-input"
             @change="valueChanged($event.target.value)"
           />
-          <output v-if="isNumericInput" class="bubble" :style="customStyle">
+          <output v-if="isQuantitative" class="bubble" :style="customStyle">
             {{ bubbleValue }}
           </output>
         </div>
@@ -41,10 +41,6 @@
 </template>
 <script>
 import get from "lodash/get";
-
-function isNumeric(value) {
-  return /^-?\d+$/.test(value);
-}
 
 export default {
   // eslint-disable-next-line vue/require-prop-types
@@ -85,16 +81,14 @@ export default {
         null
       );
     },
-    isNumericInput() {
+    isQuantitative() {
       return (
         this.question.question_info.question_responses.range_type ==
-          "Numeric (Linear)" ||
-        // left choice and right choice texts are actually numbers
-        (isNumeric(this.left_choice_text) && isNumeric(this.right_choice_text))
+        "Numeric (Linear)"
       );
     },
     inputValueText() {
-      return this.isNumericInput
+      return this.isQuantitative
         ? this.bubbleValue
         : `${this.sliderValue}% between ${this.left_choice_text} and ${this.right_choice_text}`;
     },

--- a/resources/assets/js/components/SliderResponse/SliderResponseInputs.vue
+++ b/resources/assets/js/components/SliderResponse/SliderResponseInputs.vue
@@ -3,15 +3,35 @@
     <div class="row value-slider">
       <div class="col">
         <div class="range-wrap">
+          <!-- 
+            the range of this question is set as a min="0" and max="100",
+            but these aren't the real values.
+            We need to tell users using screenreaders the actual range the presenter set, someplace, so we do that here.
+
+            TODO: The min/max values on the input should correspond to actual min/max values, not 0/100, if it's numeric. (I believe) screenreaders will read the min/max values on input. So, if the 
+            question is something like "How large is angle A?" and the range is 0-180, the input should have min="0" and max="180", not 0 and 100.
+          -->
+          <div
+            :for="`formControlRange-${question.id}`"
+            class="sr-only"
+            role="heading"
+            aria-level="3"
+          >
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <div v-html="question.text" />
+            <p>
+              Choose a value between {{ left_choice_text }} and
+              {{ right_choice_text }}
+            </p>
+          </div>
           <input
-            id="formControlRange"
-            :aria-labelledby="`question-${question.id}-heading`"
+            id="`formControlRange-${question.id}`"
             type="range"
             :disabled="disabled"
             class="form-control-range custom-range range"
             :value="sliderValue"
-            :min="left_choice_text"
-            :max="right_choice_text"
+            :min="0"
+            :max="100"
             data-cy="slider-response-input"
             @change="valueChanged($event.target.value)"
           />


### PR DESCRIPTION
As part of the accessibility review this summer, we changed the min/max of ranged inputs from a generic 0 to 100 to the actual values the presenter set so that they user heard proper values when adjusting the slider. This unfortunately broke the responses, which are computed based on a value between 0 and 100, not the set min/max.

This PR, reverts the min to be 0 and max to be 100. Then, to accommodate users with screenreaders by setting aria values: `aria-valueMin`, `aria-valueMax`, and `aria-valueText.

If a question is  **quantitative**, the `aria-valueText` read will be the same as number in `bubbleText`.  For example, if choices are between `0` and `360` and a user chooses `180` (50%), the user will hear `180` rather than `50`.

If a question is **qualitative**, the text read will be: "50% between 0 and 360."

Closes #526