### PR TITLE
fix: add message about report creation time

### DIFF
--- a/resources/assets/js/views/FolderParticipationPage/FolderParticipationPage.vue
+++ b/resources/assets/js/views/FolderParticipationPage/FolderParticipationPage.vue
@@ -20,8 +20,10 @@
             ]"
           >
           </BreadcrumbNav>
-          <h2 v-if="folder">Participation Report</h2>
-          <p>Participation for all questions within this folder.</p>
+          <div v-if="folder">
+            <h2>Participation Report</h2>
+            <p>Participation for all questions within this folder.</p>
+          </div>
         </header>
       </div>
 
@@ -70,7 +72,14 @@
         </section>
       </div>
       <div v-if="!participationSummary">
-        <Spinner> Creating Report </Spinner>
+        <Spinner>
+          <div class="text-center">
+            <h2>Creating Report</h2>
+            <p>
+              This could take a minute or two if there are a lot of responses.
+            </p>
+          </div>
+        </Spinner>
       </div>
     </div>
   </DefaultLayout>


### PR DESCRIPTION
Add some context to the spinner and load text to give users an expected timeline for building the report:
<img width="500" alt="Screenshot 2022-11-16 at 10 06 31@2x" src="https://user-images.githubusercontent.com/980170/202232261-bc7b1bd8-4cfa-4668-8127-707d302de918.png">
