### PR TITLE
[stacked on PR #561] Update to vue-select-4.0.0-beta.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "vue-google-charts": "^1.1.0",
     "vue-json-csv": "^2.1.0",
     "vue-router": "^4.0.15",
-    "vue-select": "^4.0.0-beta.3",
+    "vue-select": "^4.0.0-beta.6",
     "vue-template-compiler": "^2.7.8",
     "vuedraggable": "^4.1.0",
     "vuepress-plugin-medium-zoom": "^1.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5874,7 +5874,7 @@ vue-router@^4.0.15:
   dependencies:
     "@vue/devtools-api" "^6.4.5"
 
-vue-select@^4.0.0-beta.3:
+vue-select@^4.0.0-beta.6:
   version "4.0.0-beta.6"
   resolved "https://registry.yarnpkg.com/vue-select/-/vue-select-4.0.0-beta.6.tgz#7c250cb7c01280b54a311cb446629801b3c8df98"
   integrity sha512-K+zrNBSpwMPhAxYLTCl56gaMrWZGgayoWCLqe5rWwkB8aUbAUh7u6sXjIR7v4ckp2WKC7zEEUY27g6h1MRsIHw==


### PR DESCRIPTION
PR stacked on #561.

This updates vue-select to the latest version (that runs on Vue3).

