### PR TITLE
[Stacked on PR #561] bump vue to 3.2.45

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "socket.io-client": "^2.4.0",
     "stemmer": "^2.0.0",
     "stopword": "^2.0.2",
-    "vue": "^3.2.33",
+    "vue": "^3.2.45",
     "vue-carousel": "^0.18.0",
     "vue-chartjs": "^4.1.1",
     "vue-demi": "^0.13.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5902,7 +5902,7 @@ vue@^2.5.17:
     "@vue/compiler-sfc" "2.7.14"
     csstype "^3.1.0"
 
-vue@^3.2, vue@^3.2.33:
+vue@^3.2, vue@^3.2.45:
   version "3.2.45"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.45.tgz#94a116784447eb7dbd892167784619fef379b3c8"
   integrity sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==


### PR DESCRIPTION
Stacked on #561. 

This updates to latest version of Vue.