### PR TITLE
fix: question sort order

### DIFF
--- a/app/Http/Controllers/ChimeController.php
+++ b/app/Http/Controllers/ChimeController.php
@@ -411,19 +411,32 @@ class ChimeController extends Controller
         }
 
 
-        $questions = \App\Question::join('folders', 'folders.id','=','questions.folder_id')->join('chimes','folders.chime_id','=','chimes.id')->whereNotNull('questions.current_session_id')->where('chimes.id', $chime->id)->select('questions.*')->with('current_session')->with('current_session.question')->with('current_session.question.folder')->get(); 
+        $questions = \App\Question::join('folders', 'folders.id', '=', 'questions.folder_id')
+            ->join('chimes', 'folders.chime_id', '=', 'chimes.id')
+            ->whereNotNull('questions.current_session_id')
+            ->where('chimes.id', $chime->id)
+            ->select('questions.*')
+            ->with('current_session')
+            ->with('current_session.question')
+            ->with('current_session.question.folder')
+            ->get();
+
         $sessions = [];
 
-
-        foreach($questions as $question) {
+        foreach ($questions as $question) {
             $sessions[] = $question->current_session;
         }
 
-        usort($sessions, function($a, $b) {
-            if(strtotime($a->updated_at) == strtotime($b->updated_at)) {
+        usort($sessions, function ($a, $b) {
+            $a_time = strtotime($a->updated_at);
+            $b_time = strtotime($b->updated_at);
+
+            // If there's a tie, sort by question order
+            if ($a_time == $b_time) {
                 return $a->question->order - $b->question->order;
             }
-            return strtotime($a->updated_at)<strtotime($b->updated_at)?-1:1;
+            // sort by update time, most recent at the top
+            return $a_time < $b_time ? 1 : -1;
         });
 
 

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -251,7 +251,7 @@ function loadChime() {
     .then((res) => {
       chime.value = res.data.chime;
       document.title = chime.value.name;
-      sessions.value = res.data.sessions.reverse();
+      sessions.value = res.data.sessions;
     })
     .catch((err) => {
       if (err.response.data.status == "AttemptAuth") {

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -216,13 +216,13 @@ const filteredSession = computed(() => {
     : sessions.value;
 });
 
-const compareBy = (prop) => (a, b) => {
-  if (a[prop] > b[prop]) return -1;
-  if (a[prop] < b[prop]) return 1;
-  return 0;
-};
+// put most recent responses first
 const sortedResponses = computed(() =>
-  [...responses.value].sort(compareBy("updated_at"))
+  [...responses.value].sort((a, b) => {
+    const aDate = new Date(a.updated_at);
+    const bDate = new Date(b.updated_at);
+    return bDate - aDate;
+  })
 );
 
 const ltiLaunchWarning = computed(

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -126,7 +126,7 @@
                   <h1>No Answered Questions</h1>
                 </div>
                 <Response
-                  v-for="(response, i) in sortedResponses"
+                  v-for="(response, i) in responses"
                   v-else
                   :key="i"
                   :chime="chime"
@@ -215,15 +215,6 @@ const filteredSession = computed(() => {
     ? sessions.value.filter((s) => s.question.folder_id === props.folderId)
     : sessions.value;
 });
-
-// put most recent responses first
-const sortedResponses = computed(() =>
-  [...responses.value].sort((a, b) => {
-    const aDate = new Date(a.updated_at);
-    const bDate = new Date(b.updated_at);
-    return bDate - aDate;
-  })
-);
 
 const ltiLaunchWarning = computed(
   () =>


### PR DESCRIPTION
This resolves an issue where participants would see questions in reverse order if they joined AFTER the presenter had clicked "Open All", or when they refreshed their browser.

## Background

The intended question order for participants is:
1. `updated_at` in descending order (12:00, 11:00, 10:00), meaning the most recent on top.
2. If there's a tie – as when clicking "Open All" – questions should be sorted by their `order` property in ascending order (1,2,3)

Previously though, `getOpenQuestions` would sort questions by:
- `updated_at` in ascending order, the reverse of what we wanted (10:00, 11:00, 12:00), 
-  but sort by `order` ascending in case of ties (1,2,3).

When presenters would open one question at a time, users would see questions in the correct order because the client side would run a `reverse` on the results from the API.

But, when presenters would click "Open All", the `reverse` would cause the results from the api be ordered opposite of what was intended. These incorrect results were only seen when participant joined after the "Open All" was clicked or when they refreshed their browser. When partipants joined before questions were open, they would receive the open questions from websocket not the API, and those results were being added to the open questions list in intended order.

## Resolution

This PR:
- fixes `getOpenQuestions` method so that order of questions from the API matches the intended results: most recent first, ties resolved by order.
- removes the `reverse()` from the client-side, and uses the API as the source of truth for the order.
- removes response sorting on the client-side (for the Answered Questions tab), and just uses api results.