### PR TITLE
fix: keep question card text black

### DIFF
--- a/resources/assets/js/views/FolderPage/QuestionCard.vue
+++ b/resources/assets/js/views/FolderPage/QuestionCard.vue
@@ -323,4 +323,7 @@ export default {
   max-width: 100%;
   max-height: 100%;
 }
+.question-card a:hover {
+  color: currentColor;
+}
 </style>


### PR DESCRIPTION
Keeps question text as black (instead of blue from a:hover styles).

<img src="https://user-images.githubusercontent.com/980170/220438590-e72d79c7-c198-48e3-8d33-23df15d144d7.gif" width="500" />


Fixes #618.