### PR TITLE
fix: NLP on Free Response Statistics page + `/admin/users` page formatting fixes

### DIFF
--- a/resources/assets/js/helpers/legacyBuildWords.ts
+++ b/resources/assets/js/helpers/legacyBuildWords.ts
@@ -1,0 +1,86 @@
+import nlp from "compromise";
+import { removeStopwords } from "stopword";
+import { stemmer } from "stemmer";
+import { Response } from "../types";
+
+interface BuildWordsArgs {
+  responses: Response[];
+  textProcessing: boolean;
+  filterWords: string[];
+}
+
+interface LegacyWordListItem {
+  name: string;
+  stem: string;
+  value: number;
+}
+
+export function legacyBuildWords({
+  responses,
+  textProcessing,
+  filterWords,
+}: BuildWordsArgs): LegacyWordListItem[] {
+  const words = responses.map((r) => r.response_info.text).join("\n ");
+
+  let filteredWords;
+  let topics;
+  if (textProcessing) {
+    const doc = nlp(words);
+
+    topics = doc.topics().out("array");
+
+    filteredWords = words;
+
+    for (let i = 0; i < topics.length; i++) {
+      // remove topics words from our filtered words
+      filteredWords = filteredWords.replace(
+        new RegExp(
+          "\\b" + topics[i].replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "\\b",
+          "gi"
+        ),
+        ""
+      );
+    }
+  } else {
+    filteredWords = words;
+    topics = [];
+  }
+
+  if (filteredWords.length == 0) {
+    return [];
+  }
+
+  const wordsWithoutStops = removeStopwords(
+    filteredWords.match(/"(.*?)"|\w+/g)
+  );
+
+  const finalizedWords = wordsWithoutStops
+    .concat(topics)
+    .filter((w) => !filterWords.includes(w));
+
+  const groups = finalizedWords.reduce((acc: any[], w) => {
+    if (w.length < 2) {
+      return acc;
+    }
+    const stem = stemmer(w.toLowerCase().replace(/"/g, ""));
+    const i = acc.findIndex((e) => e.stem === stem);
+
+    if (i > -1) {
+      acc[i].value += 1;
+    } else {
+      acc.push({
+        name: w.replace(/"/g, ""),
+        value: 1,
+        stem: stem,
+      });
+    }
+
+    return acc;
+  }, []);
+
+  const sortedArray = groups.sort((a, b) => {
+    return b.value - a.value;
+  });
+
+  return sortedArray.slice(0, 200);
+}

--- a/resources/assets/js/views/PresentPage/FreeResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/FreeResponseStatistics.vue
@@ -72,9 +72,8 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import VWordCloud from "./VWordCloud.vue";
-import * as nlp from "compromise";
+import nlp from "compromise";
 import toWordFrequencyLookup from "./toWordFrequencyLookup";
-
 import type { Question, Response, WordFrequencyLookup } from "../../types";
 
 interface Props {

--- a/resources/assets/js/views/PresentPage/FreeResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/FreeResponseStatistics.vue
@@ -76,6 +76,8 @@ import nlp from "compromise";
 import toWordFrequencyLookup from "./toWordFrequencyLookup";
 import type { Question, Response, WordFrequencyLookup } from "../../types";
 
+// import { legacyBuildWords } from "../../helpers/legacyBuildWords";
+
 interface Props {
   responses: Response[];
   question: Question;
@@ -93,15 +95,47 @@ const responseTexts = computed(() =>
   props.responses.map((r) => r.response_info.text)
 );
 
-const topics = computed(() =>
-  nlp(responseTexts.value.join("\n")).topics().out("array")
-);
+function getNlpifiedWordlist(text: string) {
+  const nlpText = nlp(text);
 
-const wordFreqLookup = computed<WordFrequencyLookup>(() =>
-  processWithNLP.value
-    ? toWordFrequencyLookup(topics.value, filteredWords.value)
-    : toWordFrequencyLookup(responseTexts.value, filteredWords.value)
-);
+  const topics = nlpText.topics().out("array");
+  return topics;
+}
+
+// words that the Natural Language Processing (nlp) package
+// picks out as topics
+const nlpifiedWordlist = computed(() => {
+  const mergedText = responseTexts.value.join("\n");
+  const nlpWordList = getNlpifiedWordlist(mergedText);
+
+  //wrap each word quotes so that it's treated as a phrase
+  // by the word frequency lookup function. e.g. "New York"
+  return nlpWordList.map((t) => `"${t}"`);
+});
+
+const wordFreqLookup = computed<WordFrequencyLookup>(() => {
+  if (!processWithNLP.value) {
+    return toWordFrequencyLookup(responseTexts.value, filteredWords.value);
+  }
+
+  // nlp word list generated from the simplified word list builder
+  return toWordFrequencyLookup(nlpifiedWordlist.value, filteredWords.value);
+
+  // Below is the nlp word list generated from the legacy word list builder
+  // keeping this around for now in case we want to switch back
+
+  // return legacyBuildWords({
+  //   responses: props.responses,
+  //   textProcessing: processWithNLP.value,
+  //   filterWords: filteredWords.value,
+  // }).reduce(
+  //   (acc, wordObj) => ({
+  //     ...acc,
+  //     [wordObj.name]: wordObj.value,
+  //   }),
+  //   {}
+  // );
+});
 
 function handleWordClick(word) {
   filteredWords.value.push(word);

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -10,8 +10,7 @@
 
     <title>{{ config('app.name', 'Laravel') }}</title>
 
-    <!-- Styles -->
-    <link href="{{ asset('css/app.css') }}" rel="stylesheet">
+    @vite(['resources/assets/js/app.ts'])
 </head>
 <body>
     <div id="app">
@@ -73,8 +72,5 @@
 
         @yield('content')
     </div>
-
-    <!-- Scripts -->
-    <script src="{{ asset('js/app.js') }}"></script>
 </body>
 </html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "allowJs": true,
     // disabling: nlp-compromise doesn't like this setting
     // "esModuleInterop": true
-    "outDir": "./public/build"
+    "outDir": "./public/build",
+    "allowSyntheticDefaultImports": true
   },
   "include": ["resources"],
   "exclude": ["vendor", "node_modules", "./public/build"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5439,9 +5439,9 @@ stemmer@^2.0.0:
   integrity sha512-bkWvSX2JR4nSZFfs113kd4C6X13bBBrg4fBKv2pVdzpdQI2LA5pZcWzTFNdkYsiUNl13E4EzymSRjZ0D55jBYg==
 
 stopword@^2.0.2:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/stopword/-/stopword-2.0.5.tgz#8f3a657480f084c9f3a84132f14b05b2d29e8842"
-  integrity sha512-MgmxgmVs0Uo9G4mMqRc/QBXdPePZUnVNYqnNiv8QdCXTqHmGRw36mrjToCeNxhu/7Ifa7RxAtd/KR/GLZdnN9g==
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/stopword/-/stopword-2.0.7.tgz#8bd333a05e69cd6009f803f95dab4ce47da95ff3"
+  integrity sha512-s+uLKAxrproCLrq0Wcd3JAIjlJLx6l80b2Rzt0u8+ra5SzGkHnNG8PS3DfGmYk2TrKePDVLL4SdKYwKpgSLc+w==
 
 strict-uri-encode@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## NLP Fixes

This fixes a few things with the "Experimental" word cloud processing.

- Sometimes when the Experimental box was checked, the FreeResponseStatistics page  whitescreened with an error related to the compromise nlp package. The issue only occured when building for production (vite dev server seemed to be closing the gap in development mode). This changes `tsconfig` to allow Synthetic Default Imports so that we can `import nlp from "compromise"` even if compromise doesn't have a default export.

- This reverts how NLP works. Previously, the experimental checkbox would use nlp to  only show topics like persons places and things when checked. After discussion, it sounds like this is not the intended behavior – instead the the checkbox should allow for grouping, but also show other words and not filter them. (It may also do other things?). This PR reverts to the legacy nlp word builder function.

## `admin/users` page formatting fixes

The css and js on the admin/users page wasn't importing correctly, causing formatting issues on the admin users page. This was from references to Laravel Mix assets imports in the blade file. These have been swapped for vite-style asset imports.

Deployed on <https://cla-chimein-dev.cla.umn.edu/> for review.
