### PR TITLE
Order participant responses in Answered Questions by most recent

### DIFF
--- a/app/Http/Controllers/ResponseController.php
+++ b/app/Http/Controllers/ResponseController.php
@@ -13,7 +13,8 @@ use App\Session;
 use App\Response;
 use Auth;
 
-class ResponseController extends Controller {
+class ResponseController extends Controller
+{
 
 
     /**
@@ -40,7 +41,7 @@ class ResponseController extends Controller {
             ->orderBy("responses.id", "desc")
             ->get();
 
-        $responseModels = \App\Response::hydrate($responses->toArray());
+        $responseModels = \App\Response::hydrate($responses->toArray()); 
         $responseModels->load("session.question", "session.question.folder");
         return response()->json($responseModels);
     }
@@ -50,19 +51,20 @@ class ResponseController extends Controller {
 
         $chime = $user->chimes()->find($chime->id);
 
-        if (!$chime->sessions()->contains($session)) {
-            return response()->json(["message" => 'Session not found.'], 403);
+        if(!$chime->sessions()->contains($session)) {
+            return response()->json(["message"=>'Session not found.'], 403);
         }
 
-        if (!$session->question->current_session || $session->question->current_session->id != $session->id) {
-            return response()->json(["message" => 'Session has been closed.'], 403);
+        if(!$session->question->current_session || $session->question->current_session->id != $session->id) {
+            return response()->json(["message"=>'Session has been closed.'], 403);
         }
-
-        if ($response) {
+        
+        if($response) {
             $response->response_info = $request->get('response_info');
-        } else {
-            if (!$request->get("response_info")) {
-                return response()->json(["message" => 'Responses cannot be blank.'], 400);
+        }
+        else {
+            if(!$request->get("response_info")) {
+                return response()->json(["message"=>'Responses cannot be blank.'], 400);
             }
             $response = $session->responses()->create([
                 'response_info' => $request->get('response_info'),
@@ -71,8 +73,8 @@ class ResponseController extends Controller {
         }
 
         $response->save();
-
-        event(new SubmitResponse($chime, $session, $response, $isEdit = true));
+        
+        event(new SubmitResponse($chime, $session, $response, $isEdit=true));
 
         return response()->json($response->load("session.question", "session.question.folder"));
     }
@@ -81,12 +83,15 @@ class ResponseController extends Controller {
         $user = Auth::user();
 
         $chime = $user->chimes()->find($chime->id);
-
+        
         if ($chime != null && $chime->pivot->permission_number >= 300) {
             $response->delete();
             return response('Response Deleted', 200);
         } else {
             return response('Invalid Permissions to Delete Response', 403);
         }
+
+
     }
+
 }

--- a/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPage.vue
@@ -232,7 +232,7 @@ function updateResponse(updatedResponse) {
   const isNewResponse = responseIndex === -1;
 
   responses.value = isNewResponse
-    ? responses.value.concat(updatedResponse)
+    ? [updatedResponse, ...responses.value]
     : updateList(responseIndex, updatedResponse, responses.value);
 }
 


### PR DESCRIPTION
This resolves #650, where responses were sorted inconsistently on the answered questions tab.

In this PR:
- changes the API to order the responses by most recent `responses.updated_at` value. In cases of a tie, we use the `responses.id` to break the tie, deeming a higher `id` as more recent. (This is mostly needed for testing, when responses are rapid fire and may have the same timestamp.)
- changes client side to prepend new responses to the answered questions section
- adds tests around question response order
