### PR TITLE
fix: uncaught exception thrown by `JoinPanel` when `chime` is not well-defined

### DIFF
--- a/resources/assets/js/components/ErrorDialog.vue
+++ b/resources/assets/js/components/ErrorDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <Modal
-    :show="$store.getters.message"
+    :show="!!$store.getters.message"
     style="z-index: 15000"
     :closeable="false"
   >

--- a/resources/assets/js/views/ChimePage/ChimePage.vue
+++ b/resources/assets/js/views/ChimePage/ChimePage.vue
@@ -97,7 +97,11 @@
                   </div>
                 </template>
               </Draggable>
-              <JoinPanel :chime="chime" :includeFullUrl="true" />
+              <JoinPanel
+                v-if="!isEmpty(chime)"
+                :chime="chime"
+                :includeFullUrl="true"
+              />
             </div>
           </div>
         </div>
@@ -124,6 +128,7 @@ import {
 import DefaultLayout from "../../layouts/DefaultLayout.vue";
 import * as api from "../../common/api";
 import Back from "../../components/Back.vue";
+import { isEmpty } from "ramda";
 
 export default {
   components: {
@@ -153,6 +158,8 @@ export default {
   data() {
     return {
       isReady: false,
+      // FIXME: refactor so that `chime` is either a true
+      // chime object or null
       chime: {},
       showSettings: false,
       exportPanel: false,
@@ -196,6 +203,7 @@ export default {
     this.isReady = true;
   },
   methods: {
+    isEmpty,
     toggle(value, { setToFalse = [], setToTrue = [] } = {}) {
       this[value] = !this[value];
       setToFalse.forEach((key) => {


### PR DESCRIPTION
This fixes a few issues encountered when working on updating Cypress to v12, specifically when we  [test user promotion/demotion](https://github.com/UMN-LATIS/ChimeIn2.0/blob/develop/cypress/integration/ui/chime.test.js#LL333)

## fix: uncaught exception when Chime thrown by `JoinPanel`

When a user attempts to access a page without permissions, as when we [test user attempts to access page after demotion](https://github.com/UMN-LATIS/ChimeIn2.0/blob/develop/cypress/integration/ui/chime.test.js#LL390-L392C70), the `JoinPanel` component may throw an uncaught exception. This is because the component expects the `chime` prop to contain a well-defined chime, but instead it receives an empty `{}`. The PR only mounts `JoinPanel` if `chime` is an empty object. 

## fix: `<Modal>` expects `show` prop to be a boolean

The Modal component complains loudly in the console if it receives a `show` prop that's truthy, but not a true boolean. Currently `ErrorDialog` passes a message prop, which is a string. This casts the `message` as a Boolean.