### PR TITLE
always show user role dropdown select

### DIFF
--- a/cypress/e2e/ui/chime.test.js
+++ b/cypress/e2e/ui/chime.test.js
@@ -330,7 +330,7 @@ describe("chime UI", () => {
         );
       });
 
-      it("can promote/demote users to presenters/participants", () => {
+      it.only("can promote/demote users to presenters/participants", () => {
         api.openQuestion({
           chimeId: testChime.id,
           folderId: testFolder.id,
@@ -360,9 +360,6 @@ describe("chime UI", () => {
           .contains("student@umn.edu")
           .parent()
           .as("student-row");
-
-        // activate select (currently not active by default?)
-        cy.get("@student-row").contains("Participant").click();
         cy.get("@student-row").find("select").select("Presenter");
         cy.logout();
 
@@ -382,7 +379,6 @@ describe("chime UI", () => {
           .contains("faculty@umn.edu")
           .parent()
           .as("faculty-row");
-        cy.get("@faculty-row").contains("Presenter").click();
         cy.get("@faculty-row").find("select").select("Participant");
         cy.logout();
 

--- a/resources/assets/js/views/ChimePage/ChimeManagement.vue
+++ b/resources/assets/js/views/ChimePage/ChimeManagement.vue
@@ -89,28 +89,14 @@
                 <td>{{ u.name }}</td>
                 <td>{{ u.email }}</td>
                 <td data-cy="select-user-permissions-in-chime">
-                  <template v-if="u.editPermission">
-                    <select
-                      v-model="u.permission_number"
-                      class="form-control form-control-sm"
-                      @change="saveUsers"
-                    >
-                      <option value="100">Participant</option>
-                      <option value="300">Presenter</option>
-                    </select>
-                  </template>
-                  <span
-                    v-else
-                    class="clickToChange"
-                    @click="u.editPermission = !u.editPermission"
+                  <select
+                    v-model="u.permission_number"
+                    class="form-control form-control-sm"
+                    @change="saveUsers"
                   >
-                    <template v-if="u.permission_number == 300"
-                      >Presenter</template
-                    >
-                    <template v-if="u.permission_number == 100"
-                      >Participant</template
-                    >
-                  </span>
+                    <option value="100">Participant</option>
+                    <option value="300">Presenter</option>
+                  </select>
                 </td>
                 <td>
                   <button


### PR DESCRIPTION
This resolves an issue where users may not realize the roles are editable in the Chime Settings. The select dropdown is always shown and doesn't require a click to begin editing.

Resolves #721

<img width="500" alt="CleanShot 2023-09-06 at 12 17 24@2x" src="https://github.com/UMN-LATIS/ChimeIn2.0/assets/980170/867130cb-77f9-4e5f-9c2e-1553cca71487">
