### PR TITLE
Add pins to heatmap result statistics, make opacity/saturation configurable

### DIFF
--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -148,7 +148,11 @@ export interface MultipleChoiceQuestionInfo extends QuestionInfo {
 
 export interface FreeResponseQuestionInfo extends QuestionInfo {
   question_type: "free_response";
-  question_responses: never[];
+  question_responses:
+    | [] // default until hideWordcloud is checked
+    | {
+        hideWordcloud: boolean;
+      };
 }
 
 export interface ImageResponseQuestionInfo extends QuestionInfo {

--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -48,11 +48,14 @@ export interface Session {
 
 export type QuestionType =
   | "multiple_choice"
-  | "slider"
+  | "slider_response"
   | "free_response"
   | "image_response"
   | "heatmap_response"
-  | "text_heatmap_response";
+  | "text_heatmap_response"
+  | "pin_on_image_response"
+  | "no_response";
+
 
 export interface Question {
   id: number;

--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -197,7 +197,7 @@ export interface PinOnImageQuestionInfo extends QuestionInfo {
 export type MultipleChoiceQuestion = Question<MultipleChoiceQuestionInfo>;
 export type FreeResponseQuestion = Question<FreeResponseQuestionInfo>;
 export type ImageResponseQuestion = Question<ImageResponseQuestionInfo>;
-export type HeatmapQuestion = Question<ImageHeatmapQuestionInfo>;
+export type ImageHeatmapQuestion = Question<ImageHeatmapQuestionInfo>;
 export type SliderResponseQuestion = Question<SliderResponseQuestionInfo>;
 export type TextHeatmapQuestion = Question<TextHeatmapQuestionInfo>;
 export type PinOnImageQuestion = Question<PinOnImageQuestionInfo>;

--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -21,21 +21,78 @@ export interface SortableUser extends User {
   sortableName: string;
 }
 
-export interface Response {
+export interface Response<T extends ResponseInfo = ResponseInfo> {
   id: number;
   created_at?: string;
   updated_at?: string;
   deleted_at?: string | null;
   session_id: number;
   user_id: number;
-  response_info: {
-    question_type: QuestionType;
-    // a bunch of other stuff
-    [key: string]: any;
-  };
-
+  response_info: T;
   user: User;
 }
+
+export interface ResponseInfo {
+  question_type: QuestionType;
+  [key: string]: unknown;
+}
+
+export interface MultipleChoiceResponseInfo extends ResponseInfo {
+  question_type: "multiple_choice";
+  choice: HTMLString;
+}
+
+export interface FreeResponseResponseInfo extends ResponseInfo {
+  question_type: "free_response";
+  text: string;
+}
+
+export type StringifiedNumber = string;
+
+export interface SliderResponseResponseInfo extends ResponseInfo {
+  question_type: "slider_response";
+  // stringified number between 0-100 representing the percent between the left and right choices
+  choice: StringifiedNumber;
+}
+
+export interface ImageResponseResponseInfo extends ResponseInfo {
+  question_type: "image_response";
+  image: Filename; // "ULALG40oppc1AB0Mj2YVEmLL7FFu1rgoIv9RFxdC.jpg"
+  image_name: string; // "my-kitten-pic.jpg"
+  image_alt: string; // "a kitten. so soft."
+}
+
+export interface TextHeatmapResponseResponseInfo extends ResponseInfo {
+  question_type: "text_heatmap_response";
+  startOffset: number;
+  endOffset: number;
+}
+
+export interface ImageHeatmapResponseResponseInfo extends ResponseInfo {
+  question_type: "heatmap_response";
+  image_coordinates: {
+    // coordinates using natural image size
+    coordinate_x: number;
+    coordinate_y: number;
+  };
+}
+
+export interface PinOnImageResponseResponseInfo extends ResponseInfo {
+  question_type: "pin_on_image_response";
+  image_coordinates: {
+    // coordinates using natural image size
+    coordinate_x: number;
+    coordinate_y: number;
+  };
+}
+
+export type MultipleChoiceResponse = Response<MultipleChoiceResponseInfo>;
+export type FreeResponse = Response<FreeResponseResponseInfo>;
+export type SliderResponse = Response<SliderResponseResponseInfo>;
+export type ImageResponse = Response<ImageResponseResponseInfo>;
+export type TextHeatmapResponse = Response<TextHeatmapResponseResponseInfo>;
+export type ImageHeatmapResponse = Response<ImageHeatmapResponseResponseInfo>;
+export type PinOnImageResponse = Response<PinOnImageResponseResponseInfo>;
 
 export interface Session {
   id: number;
@@ -105,15 +162,16 @@ export interface ImageHeatmapQuestionInfo extends QuestionInfo {
   question_type: "heatmap_response";
   question_responses: {
     image: Filename; // "1jpqNOnV5Kig4FVwOf9tPIAarwvVl8nRvZrOiuLI.jpg"
-    image_name: string; // alt attribute for image
+    image_name: string; // original filename "myimage.jpg"
+    image_alt?: string;
   };
 }
 
 export interface SliderResponseQuestionInfo extends QuestionInfo {
   question_type: "slider_response";
   question_responses: {
-    left_choice_text: string;
-    right_choice_text: string;
+    left_choice_text: string | StringifiedNumber;
+    right_choice_text: string | StringifiedNumber;
     range_type: "Qualitative" | "Numeric (Linear)";
   };
 }

--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -56,27 +56,94 @@ export type QuestionType =
   | "pin_on_image_response"
   | "no_response";
 
+export type HTMLString = string;
 
-export interface Question {
+export interface Question<T extends QuestionInfo = QuestionInfo> {
   id: number;
   created_at?: string;
   updated_at?: string;
   deleted_at?: string | null;
   /** the session that's currently active within this chime */
   current_session_id: number | null;
-  /** HTML string */
-  text: string;
+  text: HTMLString;
   folder_id: number;
   order: number;
-  question_info: {
-    question_type: QuestionType;
-    /** content varies depending on question type */
-    [key: string]: any;
-  };
+  question_info: T;
   anonymous: boolean;
   allow_multiple: boolean;
   sessions: Session[];
 }
+
+export interface QuestionInfo {
+  question_type: QuestionType;
+  question_responses: unknown;
+}
+
+export interface ChoiceForMultipleChoiceQuestionInfo {
+  text: string;
+  correct: boolean;
+}
+
+export interface MultipleChoiceQuestionInfo extends QuestionInfo {
+  question_type: "multiple_choice";
+  question_responses: ChoiceForMultipleChoiceQuestionInfo[];
+}
+
+export interface FreeResponseQuestionInfo extends QuestionInfo {
+  question_type: "free_response";
+  question_responses: never[];
+}
+
+export interface ImageResponseQuestionInfo extends QuestionInfo {
+  question_type: "image_response";
+  question_responses: never[];
+}
+
+export type Filename = string;
+
+export interface ImageHeatmapQuestionInfo extends QuestionInfo {
+  question_type: "heatmap_response";
+  question_responses: {
+    image: Filename; // "1jpqNOnV5Kig4FVwOf9tPIAarwvVl8nRvZrOiuLI.jpg"
+    image_name: string; // alt attribute for image
+  };
+}
+
+export interface SliderResponseQuestionInfo extends QuestionInfo {
+  question_type: "slider_response";
+  question_responses: {
+    left_choice_text: string;
+    right_choice_text: string;
+    range_type: "Qualitative" | "Numeric (Linear)";
+  };
+}
+
+export interface TextHeatmapQuestionInfo extends QuestionInfo {
+  question_type: "text_heatmap_response";
+  question_responses: { heatmap_text: HTMLString };
+}
+
+export interface NoResponseQuestionInfo extends QuestionInfo {
+  question_type: "no_response";
+  question_responses: never[];
+}
+
+export interface PinOnImageQuestionInfo extends QuestionInfo {
+  question_type: "pin_on_image_response";
+  question_responses: {
+    image: Filename; // "1jpqNOnV5Kig4FVwOf9tPIAarwvVl8nRvZrOiuLI.jpg"
+    image_name: string; // alt attribute for image
+  };
+}
+
+export type MultipleChoiceQuestion = Question<MultipleChoiceQuestionInfo>;
+export type FreeResponseQuestion = Question<FreeResponseQuestionInfo>;
+export type ImageResponseQuestion = Question<ImageResponseQuestionInfo>;
+export type HeatmapQuestion = Question<ImageHeatmapQuestionInfo>;
+export type SliderResponseQuestion = Question<SliderResponseQuestionInfo>;
+export type TextHeatmapQuestion = Question<TextHeatmapQuestionInfo>;
+export type PinOnImageQuestion = Question<PinOnImageQuestionInfo>;
+export type NoResponseQuestion = Question<NoResponseQuestionInfo>;
 
 export interface Folder {
   id: number;

--- a/resources/assets/js/views/PresentPage/FreeResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/FreeResponseStatistics.vue
@@ -73,19 +73,24 @@
 import { computed, ref } from "vue";
 import VWordCloud from "./VWordCloud.vue";
 import toWordFrequencyLookup from "./toWordFrequencyLookup";
-import type { Question, Response, WordFrequencyLookup } from "../../types";
+import type {
+  FreeResponse,
+  FreeResponseQuestion,
+  WordFrequencyLookup,
+} from "../../types";
 import getWordFreqLookupNLP from "../../helpers/getWordFreqLookupNLP";
 
 interface Props {
-  responses: Response[];
-  question: Question;
+  responses: FreeResponse[];
+  question: FreeResponseQuestion;
 }
 
 const props = defineProps<Props>();
 const filteredWords = ref<string[]>([]);
-const hideWordcloud = computed(
-  () => props.question.question_info.question_responses.hideWordcloud
-);
+const hideWordcloud = computed(() => {
+  const question_responses = props.question.question_info.question_responses;
+  return !Array.isArray(question_responses) && question_responses.hideWordcloud;
+});
 const responsesByMostRecent = computed(() => [...props.responses].reverse());
 
 const processWithNLP = ref(false);

--- a/resources/assets/js/views/PresentPage/HeatmapResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/HeatmapResponseStatistics.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="col-sm-12">
+  <div>
     <div class="overlay-container">
-      <canvas id="simpleheat" ref="targetCanvas"></canvas>
-      <ul class="pin-container">
+      <canvas v-show="showHeatmap" id="simpleheat" ref="targetCanvas"></canvas>
+      <ul v-show="showPins" class="pin-container">
         <li
           v-for="response in responses"
           :key="response.id"
@@ -36,12 +36,36 @@
         data-cy="image-heatmap-original"
         class="img-fluid heatmap-target-image"
         :src="'/storage/' + question.question_info.question_responses.image"
+        :style="imageStyle"
         :alt="
           question.question_info.question_responses.image_alt ||
           question.question_info.question_responses.image_name
         "
         @load="renderHeatMap"
       />
+    </div>
+    <div class="image-tools">
+      <div>
+        <label class="range-group">
+          Saturation
+          <input v-model="imageSaturation" type="range" min="0" max="100" />
+        </label>
+        <label class="range-group">
+          Opacity
+          <input v-model="imageOpacity" type="range" min="0" max="100" />
+        </label>
+      </div>
+
+      <div>
+        <label class="checkbox-group">
+          <input v-model="showHeatmap" type="checkbox" />
+          Heatmap
+        </label>
+        <label class="checkbox-group">
+          <input v-model="showPins" type="checkbox" />
+          Pins
+        </label>
+      </div>
     </div>
   </div>
 </template>
@@ -60,6 +84,10 @@ interface Props {
 const props = defineProps<Props>();
 const targetImage = ref<HTMLImageElement | null>(null);
 const targetCanvas = ref<HTMLCanvasElement | null>(null);
+const imageSaturation = ref(100);
+const imageOpacity = ref(100);
+const showHeatmap = ref(true);
+const showPins = ref(true);
 
 interface Point {
   x: number;
@@ -79,6 +107,13 @@ const scaleY = computed(() => {
     return 1;
   }
   return imageHeight.value / targetImage.value.naturalHeight;
+});
+
+const imageStyle = computed<StyleValue>(() => {
+  return {
+    filter: `saturate(${imageSaturation.value}%)`,
+    opacity: imageOpacity.value / 100,
+  };
 });
 
 function getScaledImageCoords(p: Point): Point {
@@ -132,7 +167,7 @@ useResizeObserver(targetImage, renderHeatMap);
 watch(() => props.responses, renderHeatMap);
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 .heatmap-target-image {
   display: block;
   max-width: 100%;
@@ -148,6 +183,7 @@ canvas {
   right: 0;
   bottom: 0;
   left: 0;
+  z-index: 1;
 }
 
 .pin-container {
@@ -156,12 +192,16 @@ canvas {
   padding: 0;
   margin: 0;
   list-style-type: none;
+  z-index: 2;
 }
 
 .pin {
   padding: 0;
   margin: 0;
   border-radius: 50%;
+  width: 0.25rem;
+  height: 0.125rem;
+  background: rgba(#000, 0.25);
 }
 
 .pin-icon {
@@ -172,5 +212,42 @@ canvas {
   color: #007bff;
   width: 1.25rem;
   height: 1.25rem;
+}
+
+.image-tools {
+  background: #f3f3f3;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  border: 1px solid #ddd;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  flex-wrap: wrap;
+  font-size: 0.825rem;
+  margin: 1rem 0;
+
+  div {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1.5rem;
+  }
+
+  label {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+}
+
+.form-range {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  label {
+    margin: 0;
+  }
 }
 </style>

--- a/resources/assets/js/views/PresentPage/HeatmapResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/HeatmapResponseStatistics.vue
@@ -7,7 +7,10 @@
         data-cy="image-heatmap-original"
         class="img-fluid heatmap-target-image"
         :src="'/storage/' + question.question_info.question_responses.image"
-        :alt="question.question_info.question_responses.image_alt"
+        :alt="
+          question.question_info.question_responses.image_alt ||
+          question.question_info.question_responses.image_name
+        "
         @load="renderHeatMap"
       />
     </div>
@@ -17,11 +20,11 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, watch } from "vue";
 import simpleheat from "simpleheat";
-import { Question, Response } from "../../types";
+import { ImageHeatmapQuestion, ImageHeatmapResponse } from "@/types";
 
 interface Props {
-  responses: Response[];
-  question: Question;
+  responses: ImageHeatmapResponse[];
+  question: ImageHeatmapQuestion;
 }
 
 const props = defineProps<Props>();

--- a/resources/assets/js/views/PresentPage/HeatmapResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/HeatmapResponseStatistics.vue
@@ -2,6 +2,35 @@
   <div class="col-sm-12">
     <div class="overlay-container">
       <canvas id="simpleheat" ref="targetCanvas"></canvas>
+      <ul class="pin-container">
+        <li
+          v-for="response in responses"
+          :key="response.id"
+          :style="getPinDropStyle(response)"
+          class="pin"
+        >
+          <span class="sr-only">
+            {{ response.response_info.image_coordinates.coordinate_x }},
+            {{ response.response_info.image_coordinates.coordinate_y }}
+          </span>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="32"
+            height="32"
+            viewBox="0 0 32 32"
+            class="pin-icon"
+          >
+            <path
+              fill="currentColor"
+              stroke="white"
+              stroke-width="1"
+              d="M16 2A11.013 11.013 0 0 0 5 13a10.889 10.889 0 0 0 2.216 6.6s.3.395.349.452L16 30l8.439-9.953c.044-.053.345-.447.345-.447l.001-.003A10.885 10.885 0 0 0 27 13A11.013 11.013 0 0 0 16 2Zm0 15a4 4 0 1 1 4-4a4.005 4.005 0 0 1-4 4Z"
+            />
+            <circle cx="16" cy="13" r="4" fill="white" />
+          </svg>
+        </li>
+      </ul>
+
       <img
         ref="targetImage"
         data-cy="image-heatmap-original"
@@ -18,7 +47,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { StyleValue, computed, onMounted, onUnmounted, ref, watch } from "vue";
 import simpleheat from "simpleheat";
 import { ImageHeatmapQuestion, ImageHeatmapResponse } from "@/types";
 
@@ -31,6 +60,43 @@ const props = defineProps<Props>();
 const targetImage = ref<HTMLImageElement | null>(null);
 const targetCanvas = ref<HTMLCanvasElement | null>(null);
 
+interface Point {
+  x: number;
+  y: number;
+}
+
+const scaleX = computed(() => {
+  if (!targetImage.value) {
+    return 1;
+  }
+  return targetImage.value.clientWidth / targetImage.value.naturalWidth;
+});
+const scaleY = computed(() => {
+  if (!targetImage.value) {
+    return 1;
+  }
+  return targetImage.value.clientHeight / targetImage.value.naturalHeight;
+});
+
+function getScaledImageCoords(p: Point): Point {
+  return {
+    x: p.x * scaleX.value,
+    y: p.y * scaleY.value,
+  };
+}
+
+function getPinDropStyle(response: ImageHeatmapResponse): StyleValue {
+  const coords = getScaledImageCoords({
+    x: response.response_info.image_coordinates.coordinate_x,
+    y: response.response_info.image_coordinates.coordinate_y,
+  });
+  return {
+    position: "absolute",
+    top: coords.y + "px",
+    left: coords.x + "px",
+  };
+}
+
 function renderHeatMap() {
   if (!targetCanvas.value || !targetImage.value) {
     return;
@@ -38,23 +104,19 @@ function renderHeatMap() {
 
   targetCanvas.value.width = targetImage.value.clientWidth;
   targetCanvas.value.height = targetImage.value.clientHeight;
-  const scaleFactorX =
-    targetImage.value.clientWidth / targetImage.value.naturalWidth;
-  const scaleFactorY =
-    targetImage.value.clientHeight / targetImage.value.naturalHeight;
 
   const data = props.responses.map((r) => {
     return [
-      r.response_info.image_coordinates.coordinate_x * scaleFactorX,
-      r.response_info.image_coordinates.coordinate_y * scaleFactorY,
+      r.response_info.image_coordinates.coordinate_x * scaleX.value,
+      r.response_info.image_coordinates.coordinate_y * scaleY.value,
       0.1,
     ];
   });
   simpleheat("simpleheat")
     .data(data)
     .radius(
-      50 * Math.min(scaleFactorX, scaleFactorY),
-      20 * Math.min(scaleFactorX, scaleFactorY)
+      50 * Math.min(scaleX.value, scaleY.value),
+      20 * Math.min(scaleX.value, scaleY.value)
     )
     .draw();
 }
@@ -81,5 +143,33 @@ canvas {
   right: 0;
   bottom: 0;
   left: 0;
+}
+
+.pin-container {
+  position: absolute;
+  inset: 0;
+  padding: 0;
+  margin: 0;
+  list-style-type: none;
+}
+
+.pin {
+  padding: 0;
+  margin: 0;
+  width: 0.5rem;
+  height: 0.25rem;
+  border-radius: 50%;
+  background: hsla(0, 0%, 0%, 0.25);
+  backdrop-filter: blur(0.5rem);
+}
+
+.pin-icon {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translate(-50%, 0);
+  color: #007bff;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 </style>

--- a/resources/assets/js/views/PresentPage/HeatmapResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/HeatmapResponseStatistics.vue
@@ -50,6 +50,7 @@
 import { StyleValue, computed, onMounted, onUnmounted, ref, watch } from "vue";
 import simpleheat from "simpleheat";
 import { ImageHeatmapQuestion, ImageHeatmapResponse } from "@/types";
+import { useResizeObserver, useElementSize } from "@vueuse/core";
 
 interface Props {
   responses: ImageHeatmapResponse[];
@@ -65,17 +66,19 @@ interface Point {
   y: number;
 }
 
+const { width: imageWidth, height: imageHeight } = useElementSize(targetImage);
+
 const scaleX = computed(() => {
   if (!targetImage.value) {
     return 1;
   }
-  return targetImage.value.clientWidth / targetImage.value.naturalWidth;
+  return imageWidth.value / targetImage.value.naturalWidth;
 });
 const scaleY = computed(() => {
   if (!targetImage.value) {
     return 1;
   }
-  return targetImage.value.clientHeight / targetImage.value.naturalHeight;
+  return imageHeight.value / targetImage.value.naturalHeight;
 });
 
 function getScaledImageCoords(p: Point): Point {
@@ -124,6 +127,8 @@ function renderHeatMap() {
 onMounted(() => window.addEventListener("resize", renderHeatMap));
 onUnmounted(() => window.removeEventListener("resize", renderHeatMap));
 
+useResizeObserver(targetImage, renderHeatMap);
+
 watch(() => props.responses, renderHeatMap);
 </script>
 
@@ -156,11 +161,7 @@ canvas {
 .pin {
   padding: 0;
   margin: 0;
-  width: 0.5rem;
-  height: 0.25rem;
   border-radius: 50%;
-  background: hsla(0, 0%, 0%, 0.25);
-  backdrop-filter: blur(0.5rem);
 }
 
 .pin-icon {
@@ -169,7 +170,7 @@ canvas {
   left: 50%;
   transform: translate(-50%, 0);
   color: #007bff;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.25rem;
+  height: 1.25rem;
 }
 </style>

--- a/resources/assets/js/views/PresentPage/HeatmapResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/HeatmapResponseStatistics.vue
@@ -215,17 +215,17 @@ canvas {
 }
 
 .image-tools {
-  background: #f3f3f3;
+  background: #fafafa;
   padding: 0.5rem 1rem;
   border-radius: 0.25rem;
-  border: 1px solid #ddd;
+  border: 1px solid #eee;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 2rem;
   flex-wrap: wrap;
   font-size: 0.825rem;
-  margin: 1rem 0;
+  margin: 2rem 0;
 
   div {
     display: flex;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,11 @@
     "allowJs": true,
     "esModuleInterop": true,
     "outDir": "./public/build",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "paths": {
+      "@/*": ["./resources/assets/js/*"]
+    },
+    "types": ["vite/client"]
   },
   "include": ["resources"],
   "exclude": ["vendor", "node_modules", "./public/build"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "paths": {
       "@/*": ["./resources/assets/js/*"]
     },
-    "types": ["vite/client"]
+    "types": ["vite/client", "jest"]
   },
   "include": ["resources"],
   "exclude": ["vendor", "node_modules", "./public/build"]


### PR DESCRIPTION
This adds pins to heatmap results display, and allows presenters to adjust the opacity and saturation of an image to make the heatmap/pins more visible.

<img width="500" alt="ScreenShot 2023-09-15 at 11 18 29@2x" src="https://github.com/UMN-LATIS/ChimeIn2.0/assets/980170/19cc8c48-5528-4fcf-94e1-36e81070e777">
<img width="500" alt="ScreenShot 2023-09-15 at 11 19 02@2x" src="https://github.com/UMN-LATIS/ChimeIn2.0/assets/980170/7c01aa4b-bcb5-4108-8bfa-a1334e657a65">

Also: 
- adds some typing to Question and Response types
- fixes an issue where no alt would show for image heatmap. There's no `image_alt` property on heatmap question info, just `image_name`. Using `image_name` as a fallback for now, but see #726 
- fixes an issue where resizing the window wouldn't update the heatmap/pin location
- fixes a type issue with hideWordcloud. (Technically, I guess there could be problems when evaluating `responses.hideWordcloud` since `responses` could be an array?)

Questions:
- Since this is now a pin/heatmap style question, should we update the name? Other ChimeIn like apps call it something like "Drop Pin" or "Pin on Image"... but these don't have heatmaps afaik.
- Should the response input be updated to use a pin icon rather than a red circle for visual consistency?
- Do we need to do any fuzzing of coordinates so pins don't overlap? (My thinking is no, since heatmap would reveal multiple clicks on the same spot).
- Better layout for range or checkboxes? It looked strange above the image (there are a lot of control boxes on the page). Should we hide them behind a button?
- Are there better defaults when showing results? I wonder if 50% saturation and 50% opacity is better than 100%/100%?


Test screenshot still needs to be updated