### PR TITLE
Change name of "Image Heatmap" to "Clickable Image"

### DIFF
--- a/cypress/e2e/ui/imageHeatmapQuestion.test.js
+++ b/cypress/e2e/ui/imageHeatmapQuestion.test.js
@@ -66,7 +66,7 @@ describe("image heatmap", () => {
         // press down arrow to get the second "Heatmap" option.
         // This is brittle. Maybe rename "Heatmap" as "Image Heatmap" once
         // tests are working.
-        cy.get("[data-cy=question-type]").type("Image Heatmap{enter}");
+        cy.get("[data-cy=question-type]").type("Clickable Image{enter}");
         cy.get("[data-cy=question-editor]").type("Image heatmap question?");
 
         cy.get("[data-cy=image-dropzone]").attachFile("goldy-650x435.jpg");

--- a/resources/assets/js/views/PresentPage/HeatmapResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/HeatmapResponseStatistics.vue
@@ -99,7 +99,7 @@ const targetCanvas = ref<HTMLCanvasElement | null>(null);
 const imageSaturation = ref(100);
 const imageOpacity = ref(100);
 const showHeatmap = ref(true);
-const showPins = ref(true);
+const showPins = ref(false);
 const isImageLoaded = ref(false);
 
 interface Point {

--- a/resources/assets/js/views/QuestionForm/QuestionForm.vue
+++ b/resources/assets/js/views/QuestionForm/QuestionForm.vue
@@ -152,7 +152,7 @@ export default {
         },
         {
           id: "heatmap_response",
-          label: "Image Heatmap",
+          label: "Clickable Image",
         },
         {
           id: "text_heatmap_response",


### PR DESCRIPTION
Image Heatmap question now supports showing pins in addition to heatmaps. This update the name to be "Clickable Image" for clarity.

Defaults are set to show only the heatmap with full image saturation and opacity. That is, image pins will be hidden by default.

Clickable Image question results with defaults:
<img width="500" alt="ScreenShot 2023-09-26 at 12 01 03@2x" src="https://github.com/UMN-LATIS/ChimeIn2.0/assets/980170/869cbc9c-d69f-411a-b0ca-daec3455c3e0">
