### PR TITLE
increase timeout to accommodate npm

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -13,6 +13,7 @@ set('update_code_strategy', 'clone');
 set('repository', 'https://github.com/UMN-LATIS/ChimeIn2.0.git');
 
 set('keep_releases', 5);
+set('default_timeout', 600);
 
 add('shared_files', []);
 add('shared_dirs', []);


### PR DESCRIPTION
`npm ci` takes awhile to run and sometimes deployment fails with a timeout error. This seems to be worse on first deploy when there are more cache misses when fetching packages.

This changes the default timeout from `300` to `600` to give more headroom.