### PR TITLE
Add TS to PresentPage, fix a few errors

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,3 @@
-{}
+{
+  "trailingComma": "es5"
+}

--- a/resources/assets/js/helpers/logUnwrappedProxy.ts
+++ b/resources/assets/js/helpers/logUnwrappedProxy.ts
@@ -1,0 +1,28 @@
+import { toRaw, isProxy } from "vue";
+
+function unwrapProxy(obj: any): any {
+  if (isProxy(obj)) {
+    obj = toRaw(obj);
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => unwrapProxy(item));
+  }
+
+  if (obj !== null && typeof obj === "object") {
+    const unwrappedObj: any = {};
+    for (const key of Object.keys(obj)) {
+      unwrappedObj[key] = unwrapProxy(obj[key]);
+    }
+    return unwrappedObj;
+  }
+  return obj;
+}
+
+/**
+ * Logs the unwrapped version of the provided arguments.
+ * useful for debugging reactive objects.
+ */
+export function logUnwrappedProxy(...args: any[]) {
+  console.log(...args.map((arg) => unwrapProxy(arg)));
+}

--- a/resources/assets/js/hooks/useQuestionListener.ts
+++ b/resources/assets/js/hooks/useQuestionListener.ts
@@ -1,11 +1,11 @@
 import { onMounted, onUnmounted, ref, computed } from "vue";
 import { getFolderWithQuestions, getChime } from "../common/api";
 import echoClient from "../common/echoClient.js";
-import { Chime, Folder, Maybe, Question } from "../types";
+import { Chime, FolderWithQuestions, Maybe, Question } from "../types";
 
 export default function useQuestionListener({ chimeId, folderId }) {
   const usersCount = ref(0);
-  const folder = ref<Maybe<Folder>>(null);
+  const folder = ref<Maybe<FolderWithQuestions>>(null);
   const chime = ref<Maybe<Chime>>(null);
   const questions = computed<Question[]>({
     get() {

--- a/resources/assets/js/views/PresentPage/PresentPage.vue
+++ b/resources/assets/js/views/PresentPage/PresentPage.vue
@@ -8,7 +8,7 @@
 
       <Spinner v-if="!folder" />
       <div v-if="folder && chime" class="present-container">
-        <Fullscreen ref="fullscreenRef" @change="isFullscreen = !isFullscreen">
+        <Fullscreen @change="isFullscreen = !isFullscreen">
           <PresentQuestion
             v-if="currentQuestion"
             :usersCount="usersCount"
@@ -18,7 +18,7 @@
             @nextQuestion="nextQuestion"
             @previousQuestion="previousQuestion"
             @sessionUpdated="refreshQuestions"
-            @toggle="() => fullscreenRef.toggle()"
+            @toggle="isFullscreen = !isFullscreen"
             @reload="refreshQuestions"
           />
         </Fullscreen>
@@ -27,7 +27,7 @@
   </DefaultLayout>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { onMounted, ref, computed } from "vue";
 import { component as Fullscreen } from "vue-fullscreen";
 import useQuestionListener from "../../hooks/useQuestionListener";
@@ -38,25 +38,20 @@ import Spinner from "../../components/Spinner.vue";
 import { useRouter } from "vue-router";
 import { mathMod } from "ramda";
 import Back from "../../components/Back.vue";
+import * as T from "@/types";
+import axios from "@/common/axiosClient";
 
-const props = defineProps({
-  user: {
-    type: Object,
-    required: true,
-  },
-  chimeId: {
-    type: Number,
-    required: true,
-  },
-  folderId: {
-    type: Number,
-    required: true,
-  },
-  questionIndex: {
-    type: Number,
-    default: 0,
-  },
-});
+const props = withDefaults(
+  defineProps<{
+    user: T.User;
+    chimeId: number;
+    folderId: number;
+    questionIndex?: number;
+  }>(),
+  {
+    questionIndex: 0,
+  }
+);
 
 const {
   chime,
@@ -70,10 +65,9 @@ const {
 });
 
 const isFullscreen = ref(false);
-const fullscreenRef = ref(null);
 
 const currentQuestion = computed(() => {
-  if (props.questionIndex >= questions.length) {
+  if (props.questionIndex >= questions.value.length) {
     console.error(
       `No question exists at index ${props.questionIndex} in ${questions}`
     );

--- a/resources/assets/js/views/PresentPage/PresentQuestion.vue
+++ b/resources/assets/js/views/PresentPage/PresentQuestion.vue
@@ -101,11 +101,13 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import PresentPrompt from "./PresentPrompt.vue";
 import PresentResults from "./PresentResults.vue";
 import JoinPanel from "../../components/JoinPanel.vue";
 import { openQuestion, closeQuestion } from "../../common/api";
+import { PropType } from "vue";
+import * as T from "@/types";
 
 export default {
   components: {
@@ -114,9 +116,9 @@ export default {
     JoinPanel,
   },
   props: {
-    question: { type: Object, required: true },
-    chime: { type: Object, required: true },
-    folder: { type: Object, required: true },
+    question: { type: Object as PropType<T.Question>, required: true },
+    chime: { type: Object as PropType<T.Chime>, required: true },
+    folder: { type: Object as PropType<T.FolderWithQuestions>, required: true },
     usersCount: { type: Number, required: true },
   },
   emits: ["nextQuestion", "previousQuestion", "toggle", "reload"],
@@ -141,8 +143,11 @@ export default {
         return 0;
       }
       return this.question.sessions.reduce(function (accumulator, session) {
-        return accumulator + parseInt(session.responses.length);
+        return accumulator + session.responses.length;
       }, 0);
+    },
+    showJoinInstructions() {
+      return Boolean(this.chime.join_instructions);
     },
   },
   mounted() {
@@ -167,9 +172,6 @@ export default {
         folderId: this.folder.id,
         questionId: this.question.id,
       });
-    },
-    showJoinInstructions() {
-      return Boolean(this.chime.join_instructions);
     },
   },
 };


### PR DESCRIPTION
This adds Typescript to the `PresentPage` (split off from forthcoming PR for #140).  No functionality change (other than small fixes below).

Fixes:
- an issue where `showJoinInstructions` would always be true because it's in the `methods` section and not `computed`.
- a missing `.value` in `questions.value.length`
- removes unnecessary `parseInt()`  (not an error per-se since JS should coerce the number to a string when invok, but TS complains).

Adds:
- helper function to log the unwrapped version of proxy objects, which removes a bunch of noise when debugging reactive objects and props.