### PR TITLE
Adds a show results button

### DIFF
--- a/resources/assets/js/router.ts
+++ b/resources/assets/js/router.ts
@@ -56,6 +56,17 @@ const routes: RouteRecordRaw[] = [
     }),
   },
   {
+    path: "/chime/:chimeId/folder/:folderId/present/:questionIndex/results",
+    name: "presentResults",
+    component: PresentPage,
+    props: (route) => ({
+      chimeId: toInt(route.params.chimeId),
+      folderId: toInt(route.params.folderId),
+      questionIndex: toInt(route.params.questionIndex, 0),
+      isShowingResults: true,
+    }),
+  },
+  {
     path: "/chime/:chimeId/folder/:folderId/present/:questionIndex?",
     name: "present",
     component: PresentPage,
@@ -63,6 +74,7 @@ const routes: RouteRecordRaw[] = [
       chimeId: toInt(route.params.chimeId),
       folderId: toInt(route.params.folderId),
       questionIndex: toInt(route.params.questionIndex, 0),
+      isShowingResults: false,
     }),
   },
   { path: "/:pathMatch(.*)*", name: "NotFound", component: NotFoundPage },

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -83,8 +83,22 @@
               </router-link>
               <router-link
                 :to="{
+                  name: 'presentResults',
+                  params: { chimeId, folderId, questionIndex: 0 },
+                }"
+                class="btn"
+              >
+                <i class="material-icons">bar_chart</i>
+                Results
+              </router-link>
+              <router-link
+                :to="{
                   name: 'present',
-                  params: { chimeId: chimeId, folderId: folderId },
+                  params: {
+                    chimeId: chimeId,
+                    folderId: folderId,
+                    questionIndex: 0,
+                  },
                 }"
                 class="btn"
               >
@@ -563,7 +577,9 @@ ul li {
   background-color: #fff;
   line-height: 1.5;
   border-radius: 0.25rem;
-  box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  box-shadow:
+    0 1px 3px 0 rgb(0 0 0 / 0.1),
+    0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
 .folder-settings-panel__heading {

--- a/resources/assets/js/views/ParticipantPage/ParticipantResponse.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantResponse.vue
@@ -12,10 +12,10 @@
         :chime="chime"
       >
       </component>
-      <a
+      <RouterLink
         v-if="chime.students_can_view"
         class="pointer"
-        :href="
+        :to="
           '/chime/' +
           chime.id +
           '/folder/' +
@@ -23,8 +23,8 @@
           '/present/' +
           (response.session.question.order - 1)
         "
-        >View Responses</a
-      >
+        >View Responses
+      </RouterLink>
 
       <small v-if="chime.show_folder_title_to_participants" class="text-muted"
         ><strong>Folder</strong>: {{ response.session.question.folder.name }}
@@ -34,7 +34,7 @@
   </article>
 </template>
 
-<script>
+<script lang="ts">
 import MultipleChoice from "../../components/MultipleChoice/MultipleChoiceInputs.vue";
 import ImageResponse from "../../components/ImageResponse/ImageResponseInputs.vue";
 import FreeResponse from "../../components/FreeResponse/FreeResponseInputs.vue";

--- a/resources/assets/js/views/PresentPage/PresentPage.vue
+++ b/resources/assets/js/views/PresentPage/PresentPage.vue
@@ -1,7 +1,10 @@
 <template>
   <DefaultLayout :user="user" class="bg-white">
     <template #navbar-left>
-      <Back :to="`/chime/${chimeId}/folder/${folderId}`">Back to Folder</Back>
+      <Back v-if="!isStudentView" :to="`/chime/${chimeId}/folder/${folderId}`"
+        >Back to Folder</Back
+      >
+      <Back v-else :to="`/chimeParticipant/${chimeId}/${folderId}`">Back</Back>
     </template>
     <div class="present-page">
       <ErrorDialog />
@@ -15,6 +18,9 @@
             :question="currentQuestion"
             :chime="chime"
             :folder="folder"
+            :questionIndex="questionIndex"
+            :isShowingResults="isShowingResults"
+            :isStudentView="isStudentView"
             @nextQuestion="nextQuestion"
             @previousQuestion="previousQuestion"
             @sessionUpdated="refreshQuestions"
@@ -26,7 +32,6 @@
     </div>
   </DefaultLayout>
 </template>
-
 <script setup lang="ts">
 import { onMounted, ref, computed } from "vue";
 import { component as Fullscreen } from "vue-fullscreen";
@@ -47,9 +52,11 @@ const props = withDefaults(
     chimeId: number;
     folderId: number;
     questionIndex?: number;
+    isShowingResults?: boolean;
   }>(),
   {
     questionIndex: 0,
+    isShowingResults: false,
   }
 );
 
@@ -74,6 +81,10 @@ const currentQuestion = computed(() => {
     return null;
   }
   return questions.value[props.questionIndex];
+});
+
+const isStudentView = computed((): boolean => {
+  return folder.value?.student_view ?? false;
 });
 
 const router = useRouter();

--- a/resources/assets/js/views/PresentPage/PresentQuestion.vue
+++ b/resources/assets/js/views/PresentPage/PresentQuestion.vue
@@ -10,19 +10,19 @@
       <div class="row">
         <div class="col-sm-12 col-md-8 col-lg-9 present-question__inner">
           <PresentResults
-            v-if="show_results"
+            v-if="isShowingResults"
             :question="question"
             :chimeId="chime.id"
             @reload="$emit('reload')"
           />
           <PresentPrompt
-            v-if="!show_results"
+            v-if="!isShowingResults"
             :session="current_session"
             :question="question"
           />
         </div>
         <div
-          v-if="!folder.student_view"
+          v-if="!isStudentView"
           class="col-sm-12 col-md-4 col-lg-3 presentationControls"
         >
           <JoinPanel
@@ -54,10 +54,10 @@
               <button
                 data-cy="show-results-button"
                 class="btn btn-outline-primary align-items-center d-flex"
-                @click="show_results = !show_results"
+                @click="toggleShowResults"
               >
                 <i class="material-icons left">zoom_in</i>
-                <span v-if="show_results"> Hide Results </span>
+                <span v-if="isShowingResults"> Hide Results </span>
                 <span v-else> View Results </span>
               </button>
               <button
@@ -119,14 +119,12 @@ export default {
     question: { type: Object as PropType<T.Question>, required: true },
     chime: { type: Object as PropType<T.Chime>, required: true },
     folder: { type: Object as PropType<T.FolderWithQuestions>, required: true },
+    questionIndex: { type: Number, required: true },
     usersCount: { type: Number, required: true },
+    isShowingResults: { type: Boolean, required: false, default: false },
+    isStudentView: { type: Boolean, required: true },
   },
   emits: ["nextQuestion", "previousQuestion", "toggle", "reload"],
-  data() {
-    return {
-      show_results: false,
-    };
-  },
   computed: {
     current_session: function () {
       if (this.question.current_session_id) {
@@ -151,13 +149,45 @@ export default {
     },
   },
   mounted() {
-    if (this.folder.student_view) {
-      this.show_results = true;
+    // if this is a student view and we are not showing results,
+    // redirect to the results page
+    if (this.isStudentView && !this.isShowingResults) {
+      this.$router.replace({
+        name: "presentResults",
+        params: {
+          chimeId: this.chime.id,
+          folderId: this.folder.id,
+          questionId: this.question.id,
+        },
+      });
     }
   },
   methods: {
     toggle() {
       this.$emit("toggle");
+    },
+    showResults() {
+      this.$router.replace({
+        name: "presentResults",
+        params: {
+          chimeId: this.chime.id,
+          folderId: this.folder.id,
+          questionIndex: this.questionIndex,
+        },
+      });
+    },
+    showPrompt() {
+      this.$router.replace({
+        name: "present",
+        params: {
+          chimeId: this.chime.id,
+          folderId: this.folder.id,
+          questionIndex: this.questionIndex,
+        },
+      });
+    },
+    toggleShowResults() {
+      this.isShowingResults ? this.showPrompt() : this.showResults();
     },
     start_session() {
       openQuestion({


### PR DESCRIPTION
![ScreenShot 2024-06-03 at 12 46 51@2x](https://github.com/UMN-LATIS/ChimeIn2.0/assets/980170/1a9c06a0-40ae-403e-8769-91fcdf73ef2c)

Adds a new route for showing results. The route will still use the same PresentPage component, just pass a new `isShowingResults` prop.

A few updates to handle the case where students can view results. 
- Participants will see a Back button, which will take them back to the chime participation page instead of the folder page.
- Changes the  show results link from `<a>` to `<RouterLink>`.  At one point I was getting an issue were the websocket session would break with the full reload on `<a>`.  (Not sure 100% sure if this was necessary, though)

That top folder bar is getting a bit long. Might be fine, though. If we want to avoid wrapping, one option is to move "Open All/Close All" down closer to the questions. 

On dev for testing.