### PR TITLE
Add typescript to ChimePage and FolderPage

### DIFF
--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -99,7 +99,7 @@ export interface Session {
   created_at?: string;
   updated_at?: string;
   deleted_at?: string | null;
-  question_id: number;
+  question: Question;
   responses: Response[];
 }
 

--- a/resources/assets/js/views/ChimePage/ChimePage.vue
+++ b/resources/assets/js/views/ChimePage/ChimePage.vue
@@ -140,7 +140,7 @@ import { isEmpty } from "ramda";
 import { PropType } from "vue";
 import * as T from "@/types";
 import axios from "@/common/axiosClient";
-import { useStore } from "vuex";
+import store from "@/store";
 
 export default {
   components: {
@@ -275,7 +275,6 @@ export default {
         this.chime = await api.getChime(this.chimeId);
         document.title = this.chime.name;
       } catch (err) {
-        const store = useStore();
         store.commit(
           "message",
           "Could not load Chime. You may not have permission to view this page. "

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -271,7 +271,7 @@
   </DefaultLayout>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import orderBy from "lodash/orderBy";
 import { defineAsyncComponent, ref, computed, watch, onMounted } from "vue";
 import Draggable from "vuedraggable";
@@ -299,11 +299,12 @@ import {
 } from "../../common/api";
 import { useRouter } from "vue-router";
 import Icon from "../../components/Icon.vue";
-const QuestionForm = defineAsyncComponent(() =>
-  import(
-    /* webpackChunkName: "QuestionForm" */
-    "../QuestionForm/QuestionForm.vue"
-  )
+const QuestionForm = defineAsyncComponent(
+  () =>
+    import(
+      /* webpackChunkName: "QuestionForm" */
+      "../QuestionForm/QuestionForm.vue"
+    )
 );
 
 const props = defineProps({


### PR DESCRIPTION
No functionality change. Related to forthcoming PR on issue #818.

Adds TS to Chime and Folder pages fixes type complaints:
- adds existence checks for chimes
- refactors the export/settings panel toggle to work with types
- renames `selected_chime` to  `selected_chime_id` for clarity. Same with `selected_folder`.



