### PR TITLE
Add numeric question types for histograms and scatter plots

### DIFF
--- a/resources/assets/js/components/NumericResponse/BarChart.vue
+++ b/resources/assets/js/components/NumericResponse/BarChart.vue
@@ -1,35 +1,23 @@
 <template>
   <div>
-    <input v-model="bucketSize" type="number" placeholder="Bucket Size" />
     <GChart
       type="Histogram"
       :resizeDebounce="100"
-      :data="chartData"
+      :data="[[itemLabel, valueLabel], ...data]"
       :options="options"
       class="googleChart"
     />
   </div>
 </template>
 <script setup lang="ts">
-import { computed, ref } from "vue";
 import { GChart } from "vue-google-charts";
 import { GoogleChartOptions } from "vue-google-charts/dist/types";
 
-const props = defineProps<{
-  data: number[];
-  label: string;
+defineProps<{
+  data: [label: string, value: number][];
+  itemLabel: string;
+  valueLabel: string;
 }>();
-
-// 0 = auto
-const bucketSize = ref<number>(10);
-
-const chartData = computed(() => {
-  const arr: [string | number, string | number][] = [[props.label, "X"]];
-  props.data.forEach((value) => {
-    arr.push([String(value), value]);
-  });
-  return arr;
-});
 
 const options: GoogleChartOptions = {
   // height: "100%",

--- a/resources/assets/js/components/NumericResponse/BarChart.vue
+++ b/resources/assets/js/components/NumericResponse/BarChart.vue
@@ -62,4 +62,8 @@ const options = computed(
   })
 );
 </script>
-<style scoped></style>
+<style scoped>
+.googleChart {
+  min-height: 600px;
+}
+</style>

--- a/resources/assets/js/components/NumericResponse/BarChart.vue
+++ b/resources/assets/js/components/NumericResponse/BarChart.vue
@@ -1,0 +1,57 @@
+<template>
+  <div>
+    <input v-model="bucketSize" type="number" placeholder="Bucket Size" />
+    <GChart
+      type="Histogram"
+      :resizeDebounce="100"
+      :data="chartData"
+      :options="options"
+      class="googleChart"
+    />
+  </div>
+</template>
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { GChart } from "vue-google-charts";
+import { GoogleChartOptions } from "vue-google-charts/dist/types";
+
+const props = defineProps<{
+  data: number[];
+  label: string;
+}>();
+
+// 0 = auto
+const bucketSize = ref<number>(10);
+
+const chartData = computed(() => {
+  const arr: [string | number, string | number][] = [[props.label, "X"]];
+  props.data.forEach((value) => {
+    arr.push([String(value), value]);
+  });
+  return arr;
+});
+
+const options: GoogleChartOptions = {
+  // height: "100%",
+  animation: {
+    duration: 1000,
+    easing: "out",
+    startup: true,
+  },
+  legend: {
+    position: "none",
+  },
+  chartArea: {
+    top: 30,
+    left: 50,
+    width: "100%",
+  },
+  vAxis: {
+    baseline: 0,
+  },
+  tooltip: {
+    isHtml: false,
+  },
+};
+</script>
+<style scoped></style>

--- a/resources/assets/js/components/NumericResponse/BarChart.vue
+++ b/resources/assets/js/components/NumericResponse/BarChart.vue
@@ -1,5 +1,17 @@
 <template>
   <div>
+    <div class="chart-controls">
+      <div>
+        <label class="form-label"> Bucket Size </label>
+        <input
+          v-model="bucketSize"
+          class="form-control"
+          type="number"
+          placeholder="auto"
+        />
+      </div>
+    </div>
+
     <GChart
       type="Histogram"
       :resizeDebounce="100"
@@ -10,7 +22,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { GChart } from "vue-google-charts";
 import { GoogleChartOptions } from "vue-google-charts/dist/types";
 
@@ -32,6 +44,9 @@ const props = defineProps<{
 const gChartData = computed(() => {
   return [[props.itemLabel, props.xAxisLabel], ...props.data];
 });
+
+// 0 = auto
+const bucketSize = ref<number | "">("");
 
 const options = computed(
   (): GoogleChartOptions => ({
@@ -59,11 +74,31 @@ const options = computed(
     tooltip: {
       isHtml: false,
     },
+    histogram: {
+      // '' or 0 = auto
+      bucketSize: !bucketSize.value ? undefined : bucketSize.value,
+    },
   })
 );
 </script>
 <style scoped>
 .googleChart {
   min-height: 600px;
+}
+
+.chart-controls {
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: -4.75rem;
+  margin-bottom: 0.25rem;
+}
+.chart-controls label {
+  margin: 0;
+  font-size: 0.825rem;
+}
+.chart-controls input {
+  width: 8rem;
 }
 </style>

--- a/resources/assets/js/components/NumericResponse/BarChart.vue
+++ b/resources/assets/js/components/NumericResponse/BarChart.vue
@@ -10,36 +10,43 @@
   </div>
 </template>
 <script setup lang="ts">
+import { computed } from "vue";
 import { GChart } from "vue-google-charts";
 import { GoogleChartOptions } from "vue-google-charts/dist/types";
 
-defineProps<{
+const props = defineProps<{
   data: [label: string, value: number][];
   itemLabel: string;
   valueLabel: string;
 }>();
 
-const options: GoogleChartOptions = {
-  // height: "100%",
-  animation: {
-    duration: 1000,
-    easing: "out",
-    startup: true,
-  },
-  legend: {
-    position: "none",
-  },
-  chartArea: {
-    top: 30,
-    left: 50,
-    width: "100%",
-  },
-  vAxis: {
-    baseline: 0,
-  },
-  tooltip: {
-    isHtml: false,
-  },
-};
+const options = computed(
+  (): GoogleChartOptions => ({
+    // height: "100%",
+    animation: {
+      duration: 1000,
+      easing: "out",
+      startup: true,
+    },
+    legend: {
+      position: "none",
+    },
+    chartArea: {
+      top: 30,
+      left: 50,
+      width: "100%",
+    },
+    vAxis: {
+      baseline: 0,
+      title: "Responses",
+    },
+    hAxis: {
+      title: props.valueLabel,
+    },
+    tooltip: {
+      isHtml: false,
+    },
+  })
+);
 </script>
 <style scoped></style>

--- a/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class=""></div>
+</template>
+<script setup lang="ts"></script>
+<style scoped></style>

--- a/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
@@ -1,5 +1,126 @@
 <template>
-  <div class=""></div>
+  <article>
+    <div class="mb-3">
+      <label for="numeric-x-input" class="form-label">
+        {{ questionOptions.x_axis_label }}
+      </label>
+      <input
+        id="numeric-x-input"
+        v-model="localResponse.x"
+        type="number"
+        :disabled="props.disabled"
+        class="form-control"
+      />
+    </div>
+
+    <div v-if="questionOptions.chart_type === 'scatter'" class="mb-3">
+      <label for="numeric-y-input" class="form-label">
+        {{ questionOptions.y_axis_label }}
+      </label>
+      <input
+        id="numeric-y-input"
+        v-model="localResponse.y"
+        type="number"
+        :disabled="disabled"
+        class="form-control"
+      />
+    </div>
+    <div class="mb-3">
+      <button
+        v-if="!disabled"
+        class="btn btn-outline-primary"
+        variant="primary"
+        @click="handleSaveOrUpdate"
+      >
+        {{ maybeResponse?.id ? "Update" : "Save" }}
+      </button>
+
+      <button
+        v-if="
+          !disabled &&
+          question.allow_multiple &&
+          hasPreviouslySaved &&
+          !isAdditionalResponse
+        "
+        class="btn btn-outline-primary"
+        variant="primary"
+        @click="handleClearAndStartNewResponse"
+      >
+        Clear and Start a New Response
+      </button>
+    </div>
+  </article>
 </template>
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import {
+  NumericResponseQuestionInfo,
+  NumericResponseResponseInfo,
+  Question,
+  Response,
+} from "@/types";
+import { isEmpty } from "ramda";
+import { computed, reactive, ref, watch } from "vue";
+
+const props = defineProps<{
+  question: Question<NumericResponseQuestionInfo>;
+  response: Response<NumericResponseResponseInfo> | {};
+  disabled: boolean;
+}>();
+
+const emit = defineEmits<{
+  (
+    event: "recordresponse",
+    response: NumericResponseResponseInfo,
+    isAdditionalResponse: boolean
+  ): void;
+}>();
+
+// Response may be an empty object for reasons.
+// But, it's easier to deal with nulls than empty objects,
+// so we'll convert it to null.
+const maybeResponse = computed(
+  (): Response<NumericResponseResponseInfo> | null => {
+    if (isEmpty(props.response)) return null;
+    return props.response as Response<NumericResponseResponseInfo>;
+  }
+);
+
+const hasPreviouslySaved = computed(() => {
+  return maybeResponse.value?.id !== undefined;
+});
+
+const localResponse = reactive<NumericResponseResponseInfo>({
+  question_type: "numeric_response",
+  x: 0,
+  y: 0,
+});
+
+// if the question supports multiple responses, this will
+// be true when the user wants to submit a new response
+// rather than updating the existing one.
+const isAdditionalResponse = ref(false);
+
+watch(
+  maybeResponse,
+  () => {
+    localResponse.x = maybeResponse.value?.response_info?.x ?? 0;
+    localResponse.y = maybeResponse.value?.response_info?.y ?? 0;
+  },
+  { immediate: true }
+);
+
+const questionOptions = computed(() => {
+  return props.question.question_info.question_responses;
+});
+
+function handleSaveOrUpdate() {
+  emit("recordresponse", localResponse, isAdditionalResponse.value);
+}
+
+function handleClearAndStartNewResponse() {
+  localResponse.x = 0;
+  localResponse.y = 0;
+  isAdditionalResponse.value = true;
+}
+</script>
 <style scoped></style>

--- a/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
@@ -58,12 +58,13 @@ import {
   Question,
   Response,
 } from "@/types";
-import { has, isEmpty } from "ramda";
+import { isEmpty } from "ramda";
 import { computed, reactive, ref, watch } from "vue";
 
 const props = defineProps<{
   question: Question<NumericResponseQuestionInfo>;
   response: Response<NumericResponseResponseInfo> | {};
+  // whether inputs should be disabled, i.e. in the "Answered Questions" view
   disabled: boolean;
 }>();
 

--- a/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
@@ -1,29 +1,31 @@
 <template>
   <article>
-    <div class="mb-3">
-      <label for="numeric-x-input" class="form-label">
-        {{ questionOptions.x_axis_label }}
-      </label>
-      <input
-        id="numeric-x-input"
-        v-model="localResponse.x"
-        type="number"
-        :disabled="props.disabled"
-        class="form-control"
-      />
-    </div>
+    <div class="mb-3 d-flex gap-3">
+      <div>
+        <label for="numeric-x-input" class="form-label">
+          {{ questionOptions.x_axis_label }}
+        </label>
+        <input
+          id="numeric-x-input"
+          v-model="localResponse.x"
+          type="number"
+          :disabled="props.disabled"
+          class="form-control"
+        />
+      </div>
 
-    <div v-if="questionOptions.chart_type === 'scatter'" class="mb-3">
-      <label for="numeric-y-input" class="form-label">
-        {{ questionOptions.y_axis_label }}
-      </label>
-      <input
-        id="numeric-y-input"
-        v-model="localResponse.y"
-        type="number"
-        :disabled="disabled"
-        class="form-control"
-      />
+      <div v-if="questionOptions.chart_type === 'scatter'">
+        <label for="numeric-y-input" class="form-label">
+          {{ questionOptions.y_axis_label }}
+        </label>
+        <input
+          id="numeric-y-input"
+          v-model="localResponse.y"
+          type="number"
+          :disabled="disabled"
+          class="form-control"
+        />
+      </div>
     </div>
     <div class="mb-3">
       <button
@@ -44,9 +46,9 @@
         "
         class="btn btn-outline-primary"
         variant="primary"
-        @click="handleClearAndStartNewResponse"
+        @click="saveAsNewResponse"
       >
-        Clear and Start a New Response
+        Save as New Response
       </button>
     </div>
   </article>
@@ -123,10 +125,9 @@ function handleSaveOrUpdate() {
   emit("recordresponse", localResponse, false);
 }
 
-function handleClearAndStartNewResponse() {
-  localResponse.x = 0;
-  localResponse.y = 0;
-  isCreatingNewResponse.value = true;
+function saveAsNewResponse() {
+  emit("recordresponse", localResponse, true);
+  isCreatingNewResponse.value = false;
 }
 </script>
 <style scoped></style>

--- a/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
@@ -27,28 +27,36 @@
         />
       </div>
     </div>
-    <div class="mb-3">
+    <div class="mb-3 d-flex gap-2">
       <button
-        v-if="!disabled"
+        v-if="!disabled && (!hasExistingResponse || hasStartedNewResponse)"
+        class="btn btn-outline-primary"
+        @click="handleSave"
+      >
+        Save
+      </button>
+
+      <button
+        v-else-if="!disabled"
         class="btn btn-outline-primary"
         variant="primary"
-        @click="handleSaveOrUpdate"
+        @click="handleUpdate"
       >
-        {{ isCreatingNewResponse ? "Save" : "Update" }}
+        Update
       </button>
 
       <button
         v-if="
           !disabled &&
           question.allow_multiple &&
-          !isCreatingNewResponse &&
-          hasExistingResponse
+          hasExistingResponse &&
+          !hasStartedNewResponse
         "
         class="btn btn-outline-primary"
         variant="primary"
-        @click="saveAsNewResponse"
+        @click="handleClearAndStartNewResponse"
       >
-        Save as New Response
+        Clear and Start a New Response
       </button>
     </div>
   </article>
@@ -91,8 +99,6 @@ const maybeResponse = computed(
 
 const hasExistingResponse = computed(() => !!maybeResponse.value?.id);
 
-const isCreatingNewResponse = ref(!hasExistingResponse.value);
-
 const localResponse = reactive<NumericResponseResponseInfo>({
   question_type: "numeric_response",
   x: 0,
@@ -112,22 +118,28 @@ const questionOptions = computed(() => {
   return props.question.question_info.question_responses;
 });
 
-function handleSaveOrUpdate() {
-  // if this is a new response, we need to save it
-  // and mark that we're not creating a new response anymore
-  if (isCreatingNewResponse.value) {
-    emit("recordresponse", localResponse, true);
-    isCreatingNewResponse.value = false;
-    return;
-  }
+function handleSave() {
+  emit("recordresponse", localResponse, true);
+  hasStartedNewResponse.value = false;
+}
 
-  // otherwise, we're updating an existing response
+function handleUpdate() {
   emit("recordresponse", localResponse, false);
 }
 
-function saveAsNewResponse() {
-  emit("recordresponse", localResponse, true);
-  isCreatingNewResponse.value = false;
+const hasStartedNewResponse = ref(false);
+function handleClearAndStartNewResponse() {
+  localResponse.x = 0;
+  localResponse.y = 0;
+  hasStartedNewResponse.value = true;
 }
 </script>
-<style scoped></style>
+<style scoped>
+.btn.btn-tertiary {
+  display: block;
+  text-transform: uppercase;
+  font-size: 0.825rem;
+  color: #333;
+  background: #f3f3f3;
+}
+</style>

--- a/resources/assets/js/components/NumericResponse/ScatterPlot.vue
+++ b/resources/assets/js/components/NumericResponse/ScatterPlot.vue
@@ -33,6 +33,39 @@ const props = defineProps<{
 type TrendlineType = "none" | "linear" | "quadratic" | "cubic" | "exponential";
 const trendlineType = ref<TrendlineType>("none");
 
+const toTrendline = (type: TrendlineType) => {
+  const trendline = {
+    type,
+    color: "green",
+    lineWidth: 3,
+    opacity: 0.3,
+    showR2: true,
+    visibleInLegend: true,
+  };
+
+  if (type === "none") {
+    return null;
+  }
+
+  if (type === "quadratic") {
+    return {
+      ...trendline,
+      type: "polynomial",
+      degree: 2,
+    };
+  }
+
+  if (type === "cubic") {
+    return {
+      ...trendline,
+      type: "polynomial",
+      degree: 3,
+    };
+  }
+
+  return trendline;
+};
+
 const options = computed(
   (): GoogleChartOptions => ({
     animation: {
@@ -46,7 +79,7 @@ const options = computed(
     chartArea: {
       top: 30,
       left: 50,
-      bottom: 30,
+      bottom: 60,
       width: "100%",
     },
     vAxis: {
@@ -60,14 +93,7 @@ const options = computed(
       isHtml: false,
     },
     trendlines: {
-      0: {
-        type: "linear",
-        color: "green",
-        lineWidth: 3,
-        opacity: 0.3,
-        showR2: true,
-        visibleInLegend: true,
-      },
+      0: toTrendline(trendlineType.value),
     },
   })
 );
@@ -84,6 +110,7 @@ const options = computed(
   align-items: baseline;
   /* hack to reduce whitespace and make appear aligned with session dropdown */
   margin-top: -3.4rem;
+  margin-bottom: 0.25rem;
 }
 .chart-controls select {
   width: auto;

--- a/resources/assets/js/components/NumericResponse/ScatterPlot.vue
+++ b/resources/assets/js/components/NumericResponse/ScatterPlot.vue
@@ -11,12 +11,26 @@
       </select>
     </div>
     <GChart
+      v-if="data.length"
       type="ScatterChart"
       :resizeDebounce="100"
       :data="[[xAxisLabel, yAxisLabel], ...data]"
       :options="options"
       class="googleChart"
     />
+    <p
+      v-else
+      style="
+        min-height: 10rem;
+        display: grid;
+        place-content: center;
+        background: #f3f3f3;
+        border-radius: 0.5rem;
+        margin-top: 1rem;
+      "
+    >
+      No data yet
+    </p>
   </div>
 </template>
 <script setup lang="ts">

--- a/resources/assets/js/components/NumericResponse/ScatterPlot.vue
+++ b/resources/assets/js/components/NumericResponse/ScatterPlot.vue
@@ -1,5 +1,15 @@
 <template>
   <div>
+    <div class="chart-controls">
+      <label>Trendline</label>
+      <select v-model="trendlineType" class="form-control">
+        <option value="none">None</option>
+        <option value="linear">Linear</option>
+        <option value="exponential">Exponential</option>
+        <option value="quadratic">Quadratic</option>
+        <option value="cubic">Cubic</option>
+      </select>
+    </div>
     <GChart
       type="ScatterChart"
       :resizeDebounce="100"
@@ -10,7 +20,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { GChart } from "vue-google-charts";
 import { GoogleChartOptions } from "vue-google-charts/dist/types";
 
@@ -20,9 +30,11 @@ const props = defineProps<{
   yAxisLabel: string;
 }>();
 
+type TrendlineType = "none" | "linear" | "quadratic" | "cubic" | "exponential";
+const trendlineType = ref<TrendlineType>("none");
+
 const options = computed(
   (): GoogleChartOptions => ({
-    // height: "100%",
     animation: {
       duration: 1000,
       easing: "out",
@@ -34,6 +46,7 @@ const options = computed(
     chartArea: {
       top: 30,
       left: 50,
+      bottom: 30,
       width: "100%",
     },
     vAxis: {
@@ -46,7 +59,33 @@ const options = computed(
     tooltip: {
       isHtml: false,
     },
+    trendlines: {
+      0: {
+        type: "linear",
+        color: "green",
+        lineWidth: 3,
+        opacity: 0.3,
+        showR2: true,
+        visibleInLegend: true,
+      },
+    },
   })
 );
 </script>
-<style scoped></style>
+<style scoped>
+.googleChart {
+  min-height: 50vh;
+}
+
+.chart-controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  align-items: baseline;
+  /* hack to reduce whitespace and make appear aligned with session dropdown */
+  margin-top: -3.4rem;
+}
+.chart-controls select {
+  width: auto;
+}
+</style>

--- a/resources/assets/js/components/NumericResponse/ScatterPlot.vue
+++ b/resources/assets/js/components/NumericResponse/ScatterPlot.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <GChart
-      type="Histogram"
+      type="ScatterChart"
       :resizeDebounce="100"
-      :data="gChartData"
+      :data="[[xAxisLabel, yAxisLabel], ...data]"
       :options="options"
       class="googleChart"
     />
@@ -15,23 +15,10 @@ import { GChart } from "vue-google-charts";
 import { GoogleChartOptions } from "vue-google-charts/dist/types";
 
 const props = defineProps<{
-  data: [label: string, value: number][];
-  itemLabel: string;
+  data: [x: number, y: number][];
   xAxisLabel: string;
+  yAxisLabel: string;
 }>();
-
-/**
- * Example data: first row is labels
- * [["User", "Cups of Coffee per day"],
- *  ["Alice", 0],
- *  ["Bob", 2],
- *  ["Charlie", 2],
- *  ...
- * ]
- */
-const gChartData = computed(() => {
-  return [[props.itemLabel, props.xAxisLabel], ...props.data];
-});
 
 const options = computed(
   (): GoogleChartOptions => ({
@@ -51,7 +38,7 @@ const options = computed(
     },
     vAxis: {
       baseline: 0,
-      title: "Responses",
+      title: props.yAxisLabel,
     },
     hAxis: {
       title: props.xAxisLabel,

--- a/resources/assets/js/components/NumericResponse/ScatterPlot.vue
+++ b/resources/assets/js/components/NumericResponse/ScatterPlot.vue
@@ -93,11 +93,11 @@ const options = computed(
     chartArea: {
       top: 30,
       left: 50,
+      right: 8,
       bottom: 60,
       width: "100%",
     },
     vAxis: {
-      baseline: 0,
       title: props.yAxisLabel,
     },
     hAxis: {

--- a/resources/assets/js/icons/IconChartBar.vue
+++ b/resources/assets/js/icons/IconChartBar.vue
@@ -1,0 +1,19 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 256 256"
+  >
+    <path
+      fill="currentColor"
+      d="M224 200h-8V40a8 8 0 0 0-8-8h-56a8 8 0 0 0-8 8v40H96a8 8 0 0 0-8 8v40H48a8 8 0 0 0-8 8v64h-8a8 8 0 0 0 0 16h192a8 8 0 0 0 0-16M160 48h40v152h-40Zm-56 48h40v104h-40Zm-48 48h32v56H56Z"
+    ></path>
+  </svg>
+</template>
+
+<script lang="ts">
+export default {
+  name: "PhChartBar",
+};
+</script>

--- a/resources/assets/js/icons/IconChartScatter.vue
+++ b/resources/assets/js/icons/IconChartScatter.vue
@@ -1,0 +1,19 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 256 256"
+  >
+    <path
+      fill="currentColor"
+      d="M232 208a8 8 0 0 1-8 8H32a8 8 0 0 1-8-8V48a8 8 0 0 1 16 0v152h184a8 8 0 0 1 8 8m-100-48a12 12 0 1 0-12-12a12 12 0 0 0 12 12m-24-56a12 12 0 1 0-12-12a12 12 0 0 0 12 12m-32 72a12 12 0 1 0-12-12a12 12 0 0 0 12 12m96-48a12 12 0 1 0-12-12a12 12 0 0 0 12 12m24-40a12 12 0 1 0-12-12a12 12 0 0 0 12 12m-20 76a12 12 0 1 0 12-12a12 12 0 0 0-12 12"
+    ></path>
+  </svg>
+</template>
+
+<script lang="ts">
+export default {
+  name: "PhChartScatter",
+};
+</script>

--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -86,6 +86,12 @@ export interface PinOnImageResponseResponseInfo extends ResponseInfo {
   };
 }
 
+export interface NumericResponseResponseInfo extends ResponseInfo {
+  question_type: "numeric_response";
+  x: number;
+  y: number;
+}
+
 export type MultipleChoiceResponse = Response<MultipleChoiceResponseInfo>;
 export type FreeResponse = Response<FreeResponseResponseInfo>;
 export type SliderResponse = Response<SliderResponseResponseInfo>;
@@ -111,7 +117,8 @@ export type QuestionType =
   | "heatmap_response"
   | "text_heatmap_response"
   | "pin_on_image_response"
-  | "no_response";
+  | "no_response"
+  | "numeric_response";
 
 export type HTMLString = string;
 
@@ -195,6 +202,15 @@ export interface PinOnImageQuestionInfo extends QuestionInfo {
   question_responses: {
     image: Filename; // "1jpqNOnV5Kig4FVwOf9tPIAarwvVl8nRvZrOiuLI.jpg"
     image_name: string; // alt attribute for image
+  };
+}
+
+export interface NumericResponseQuestionInfo extends QuestionInfo {
+  question_type: "numeric_response";
+  question_responses: {
+    chart_type: "bar" | "scatter";
+    x_axis_label: string;
+    y_axis_label?: string; // only for scatter
   };
 }
 

--- a/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantPrompt.vue
@@ -63,6 +63,7 @@ import TextHeatmapResponse from "../../components/TextHeatmap/TextHeatmapRespons
 import NoResponse from "../../components/NoResponse/NoResponseInputs.vue";
 import SliderResponse from "../../components/SliderResponse/SliderResponseInputs.vue";
 import ImageHeatmapResponse from "../../components/ImageHeatmapResponse/ImageHeatmapResponseInputs.vue";
+import NumericResponse from "../../components/NumericResponse/NumericResponseInputs.vue";
 
 export default {
   components: {
@@ -73,6 +74,7 @@ export default {
     free_response: FreeResponse,
     slider_response: SliderResponse,
     heatmap_response: ImageHeatmapResponse,
+    numeric_response: NumericResponse,
   },
   props: {
     session: {

--- a/resources/assets/js/views/ParticipantPage/ParticipantResponse.vue
+++ b/resources/assets/js/views/ParticipantPage/ParticipantResponse.vue
@@ -42,6 +42,7 @@ import TextHeatmapResponse from "../../components/TextHeatmap/TextHeatmapRespons
 import NoResponse from "../../components/NoResponse/NoResponseInputs.vue";
 import SliderResponse from "../../components/SliderResponse/SliderResponseInputs.vue";
 import ImageHeatmapResponse from "../../components/ImageHeatmapResponse/ImageHeatmapResponseInputs.vue";
+import NumericResponse from "../../components/NumericResponse/NumericResponseInputs.vue";
 
 export default {
   components: {
@@ -52,6 +53,7 @@ export default {
     free_response: FreeResponse,
     slider_response: SliderResponse,
     heatmap_response: ImageHeatmapResponse,
+    numeric_response: NumericResponse,
   },
   props: {
     response: {

--- a/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="">
+    <div v-if="chartType === 'bar'" class="chart-container">
+      <BarChart :data="barChartData" :label="questionOptions.x_axis_label" />
+    </div>
+    <div v-else-if="chartType === 'scatter'">Scatter Chart</div>
+  </div>
+</template>
+<script setup lang="ts">
+import BarChart from "@/components/NumericResponse/BarChart.vue";
+import type {
+  NumericResponseResponseInfo,
+  NumericResponseQuestionInfo,
+  Question,
+  Response,
+} from "@/types";
+import { computed } from "vue";
+
+const props = defineProps<{
+  responses: Response<NumericResponseResponseInfo>[];
+  question: Question<NumericResponseQuestionInfo>;
+}>();
+
+const chartType = computed(
+  () => props.question.question_info.question_responses.chart_type
+);
+
+const responseInfo = computed(() => {
+  return props.responses.map((response) => response.response_info);
+});
+
+const questionOptions = computed(() => {
+  return props.question.question_info.question_responses;
+});
+
+const barChartData = computed(() => {
+  return responseInfo.value.map((info) => info.x);
+});
+</script>
+<style scoped></style>

--- a/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="">
+  <div>
     <BarChart
       v-if="chartType === 'bar'"
       :data="barChartData"

--- a/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="">
     <div v-if="chartType === 'bar'" class="chart-container">
-      <BarChart :data="barChartData" :label="questionOptions.x_axis_label" />
+      <BarChart
+        :data="barChartData"
+        :itemLabel="question.anonymous ? 'Response ID' : 'User'"
+        :valueLabel="questionOptions.x_axis_label"
+      />
     </div>
     <div v-else-if="chartType === 'scatter'">Scatter Chart</div>
   </div>
@@ -25,16 +29,20 @@ const chartType = computed(
   () => props.question.question_info.question_responses.chart_type
 );
 
-const responseInfo = computed(() => {
-  return props.responses.map((response) => response.response_info);
-});
-
 const questionOptions = computed(() => {
   return props.question.question_info.question_responses;
 });
 
-const barChartData = computed(() => {
-  return responseInfo.value.map((info) => info.x);
+const barChartData = computed((): [label: string, value: number][] => {
+  return props.responses.map((response, index) => {
+    // is this question anonymous? If so, then just label
+    // with the response id, otherwise use username
+    const label = props.question.anonymous
+      ? `Response ${index + 1}`
+      : response.user.name;
+
+    return [label, response.response_info.x];
+  });
 });
 </script>
 <style scoped></style>

--- a/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
@@ -1,17 +1,22 @@
 <template>
   <div class="">
-    <div v-if="chartType === 'bar'" class="chart-container">
-      <BarChart
-        :data="barChartData"
-        :itemLabel="question.anonymous ? 'Response ID' : 'User'"
-        :valueLabel="questionOptions.x_axis_label"
-      />
-    </div>
-    <div v-else-if="chartType === 'scatter'">Scatter Chart</div>
+    <BarChart
+      v-if="chartType === 'bar'"
+      :data="barChartData"
+      :itemLabel="question.anonymous ? 'Response ID' : 'User'"
+      :xAxisLabel="questionOptions.x_axis_label"
+    />
+    <ScatterPlot
+      v-else-if="chartType === 'scatter'"
+      :data="scatterPlotData"
+      :xAxisLabel="questionOptions.x_axis_label || 'X'"
+      :yAxisLabel="questionOptions.y_axis_label || 'Y'"
+    />
   </div>
 </template>
 <script setup lang="ts">
 import BarChart from "@/components/NumericResponse/BarChart.vue";
+import ScatterPlot from "@/components/NumericResponse/ScatterPlot.vue";
 import type {
   NumericResponseResponseInfo,
   NumericResponseQuestionInfo,
@@ -43,6 +48,13 @@ const barChartData = computed((): [label: string, value: number][] => {
 
     return [label, response.response_info.x];
   });
+});
+
+const scatterPlotData = computed((): [x: number, y: number][] => {
+  return props.responses.map((response) => [
+    response.response_info.x,
+    response.response_info.y,
+  ]);
 });
 </script>
 <style scoped></style>

--- a/resources/assets/js/views/PresentPage/PresentResults.vue
+++ b/resources/assets/js/views/PresentPage/PresentResults.vue
@@ -38,47 +38,57 @@ import { defineAsyncComponent } from "vue";
 
 export default {
   components: {
-    slider_response_statistics: defineAsyncComponent(() =>
-      import(
-        /* webpackChunkName: "SliderResponseStatistics" */
-        "./SliderStatistics.vue"
-      )
+    slider_response_statistics: defineAsyncComponent(
+      () =>
+        import(
+          /* webpackChunkName: "SliderResponseStatistics" */
+          "./SliderStatistics.vue"
+        )
     ),
-    multiple_choice_statistics: defineAsyncComponent(() =>
-      import(
-        /* webpackChunkName: "MultipleChoiceStatistics" */
-        "./MultipleChoiceStatistics.vue"
-      )
+    multiple_choice_statistics: defineAsyncComponent(
+      () =>
+        import(
+          /* webpackChunkName: "MultipleChoiceStatistics" */
+          "./MultipleChoiceStatistics.vue"
+        )
     ),
-    image_response_statistics: defineAsyncComponent(() =>
-      import(
-        /* webpackChunkName: "ImageResponseStatistics" */
-        "./ImageResponseStatistics.vue"
-      )
+    image_response_statistics: defineAsyncComponent(
+      () =>
+        import(
+          /* webpackChunkName: "ImageResponseStatistics" */
+          "./ImageResponseStatistics.vue"
+        )
     ),
-    free_response_statistics: defineAsyncComponent(() =>
-      import(
-        /* webpackChunkName: "FreeResponseStatistics" */
-        "./FreeResponseStatistics.vue"
-      )
+    free_response_statistics: defineAsyncComponent(
+      () =>
+        import(
+          /* webpackChunkName: "FreeResponseStatistics" */
+          "./FreeResponseStatistics.vue"
+        )
     ),
-    text_heatmap_response_statistics: defineAsyncComponent(() =>
-      import(
-        /* webpackChunkName: "TextHeatmapresponseStatistics" */
-        "./TextHeatmapResponseStatistics.vue"
-      )
+    text_heatmap_response_statistics: defineAsyncComponent(
+      () =>
+        import(
+          /* webpackChunkName: "TextHeatmapresponseStatistics" */
+          "./TextHeatmapResponseStatistics.vue"
+        )
     ),
-    no_response_statistics: defineAsyncComponent(() =>
-      import(
-        /* webpackChunkName: "FreeResponseStatistics" */
-        "./FreeResponseStatistics.vue"
-      )
+    no_response_statistics: defineAsyncComponent(
+      () =>
+        import(
+          /* webpackChunkName: "FreeResponseStatistics" */
+          "./FreeResponseStatistics.vue"
+        )
     ),
-    heatmap_response_statistics: defineAsyncComponent(() =>
-      import(
-        /* webpackChunkName: "HeatmapResponseStatistics" */
-        "./HeatmapResponseStatistics.vue"
-      )
+    heatmap_response_statistics: defineAsyncComponent(
+      () =>
+        import(
+          /* webpackChunkName: "HeatmapResponseStatistics" */
+          "./HeatmapResponseStatistics.vue"
+        )
+    ),
+    numeric_response_statistics: defineAsyncComponent(
+      () => import("./NumericResponseStatistics.vue")
     ),
   },
   props: ["sessions", "session", "question", "chimeId"],

--- a/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
+++ b/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
@@ -9,10 +9,10 @@
           class="sr-only"
           name="chart-type"
           value="bar"
-          :checked="question_responses.chart_type === 'bar'"
+          :checked="typedQuestionResponsesProp.chart_type === 'bar'"
           @change="
             $emit('update:question_responses', {
-              ...question_responses,
+              ...typedQuestionResponsesProp,
               chart_type: 'bar',
             })
           "
@@ -29,10 +29,10 @@
           name="chart-type"
           value="scatter"
           class="sr-only"
-          :checked="question_responses.chart_type === 'scatter'"
+          :checked="typedQuestionResponsesProp.chart_type === 'scatter'"
           @change="
             $emit('update:question_responses', {
-              ...question_responses,
+              ...typedQuestionResponsesProp,
               chart_type: 'scatter',
             })
           "
@@ -50,12 +50,12 @@
         <input
           type="text"
           class="form-control"
-          :value="question_responses.x_axis_label"
+          :value="typedQuestionResponsesProp.x_axis_label"
           required
           @input="
             (event) =>
               $emit('update:question_responses', {
-                ...question_responses,
+                ...typedQuestionResponsesProp,
                 x_axis_label: (event.target as HTMLInputElement).value,
               })
           "
@@ -63,7 +63,7 @@
       </div>
     </div>
 
-    <div v-if="question_responses.chart_type === 'scatter'" class="row">
+    <div v-if="typedQuestionResponsesProp.chart_type === 'scatter'" class="row">
       <label for="x-axis-label" class="col-form-label col-sm-3">
         Y Axis Label
       </label>
@@ -71,12 +71,12 @@
         <input
           type="text"
           class="form-control"
-          :value="question_responses.y_axis_label"
-          :required="question_responses.chart_type === 'scatter'"
+          :value="typedQuestionResponsesProp.y_axis_label"
+          :required="typedQuestionResponsesProp.chart_type === 'scatter'"
           @input="
             (event) =>
               $emit('update:question_responses', {
-                ...question_responses,
+                ...typedQuestionResponsesProp,
                 y_axis_label: (event.target as HTMLInputElement).value,
               })
           "
@@ -89,20 +89,22 @@
 import IconChartBar from "@/icons/IconChartBar.vue";
 import IconChartScatter from "@/icons/IconChartScatter.vue";
 import { NumericResponseQuestionInfo } from "@/types";
+import { computed } from "vue";
 
-withDefaults(
-  defineProps<{
-    // eslint-disable-next-line vue/prop-name-casing
-    question_responses: NumericResponseQuestionInfo["question_responses"];
-  }>(),
-  {
-    question_responses: () => ({
-      chart: "bar",
-      x_axis_label: "",
-      y_axis_label: "",
-    }),
-  }
-);
+const props = defineProps<{
+  /**
+   * It's possible – likely even – that the passed question_responses prop will
+   * be a value like `[]` (the default set by a Multiple Choice) or some
+   * other value that doesn't match the NumericResponseQuestionInfo type.
+   *
+   * What this means is that we need to check that the question_responses prop
+   * is an object with the properties we expect.
+   */
+  // eslint-disable-next-line vue/prop-name-casing
+  question_responses:
+    | NumericResponseQuestionInfo["question_responses"]
+    | unknown;
+}>();
 
 defineEmits<{
   (
@@ -110,6 +112,31 @@ defineEmits<{
     value: NumericResponseQuestionInfo["question_responses"]
   ): void;
 }>();
+
+function isNumericResponseQuestionInfo(
+  question_responses:
+    | NumericResponseQuestionInfo["question_responses"]
+    | unknown
+): question_responses is NumericResponseQuestionInfo["question_responses"] {
+  return (
+    typeof question_responses === "object" &&
+    question_responses !== null &&
+    "chart_type" in question_responses &&
+    "x_axis_label" in question_responses &&
+    "y_axis_label" in question_responses
+  );
+}
+
+const typedQuestionResponsesProp = computed(() => {
+  if (isNumericResponseQuestionInfo(props.question_responses)) {
+    return props.question_responses;
+  }
+  return {
+    chart_type: "bar",
+    x_axis_label: "",
+    y_axis_label: "",
+  } as NumericResponseQuestionInfo["question_responses"];
+});
 </script>
 <style scoped>
 .type-select {

--- a/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
+++ b/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
@@ -19,7 +19,7 @@
         />
 
         <IconChartBar />
-        Bar Chart
+        Histogram
       </label>
 
       <label for="scatter-chart">

--- a/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
+++ b/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
@@ -9,11 +9,11 @@
           class="sr-only"
           name="chart-type"
           value="bar"
-          :checked="question_responses.type === 'bar'"
+          :checked="question_responses.chart_type === 'bar'"
           @change="
             $emit('update:question_responses', {
               ...question_responses,
-              type: 'bar',
+              chart_type: 'bar',
             })
           "
         />
@@ -29,11 +29,11 @@
           name="chart-type"
           value="scatter"
           class="sr-only"
-          :checked="question_responses.type === 'scatter'"
+          :checked="question_responses.chart_type === 'scatter'"
           @change="
             $emit('update:question_responses', {
               ...question_responses,
-              type: 'scatter',
+              chart_type: 'scatter',
             })
           "
         />
@@ -63,7 +63,7 @@
       </div>
     </div>
 
-    <div v-if="question_responses.type === 'scatter'" class="row">
+    <div v-if="question_responses.chart_type === 'scatter'" class="row">
       <label for="x-axis-label" class="col-form-label col-sm-3">
         Y Axis Label
       </label>
@@ -72,7 +72,7 @@
           type="text"
           class="form-control"
           :value="question_responses.y_axis_label"
-          :required="question_responses.type === 'scatter'"
+          :required="question_responses.chart_type === 'scatter'"
           @input="
             (event) =>
               $emit('update:question_responses', {
@@ -86,24 +86,18 @@
   </section>
 </template>
 <script setup lang="ts">
-import VSelect from "@/components/VSelect.vue";
 import IconChartBar from "@/icons/IconChartBar.vue";
 import IconChartScatter from "@/icons/IconChartScatter.vue";
-
-interface NumericQuestionResponseOptions {
-  type: "bar" | "scatter";
-  x_axis_label: string;
-  y_axis_label: string;
-}
+import { NumericResponseQuestionInfo } from "@/types";
 
 withDefaults(
   defineProps<{
     // eslint-disable-next-line vue/prop-name-casing
-    question_responses: NumericQuestionResponseOptions;
+    question_responses: NumericResponseQuestionInfo["question_responses"];
   }>(),
   {
     question_responses: () => ({
-      type: "bar",
+      chart: "bar",
       x_axis_label: "",
       y_axis_label: "",
     }),
@@ -111,7 +105,10 @@ withDefaults(
 );
 
 defineEmits<{
-  (event: "update:question_responses", value: NumericQuestionResponseOptions);
+  (
+    event: "update:question_responses",
+    value: NumericResponseQuestionInfo["question_responses"]
+  ): void;
 }>();
 </script>
 <style scoped>

--- a/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
+++ b/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
@@ -1,0 +1,144 @@
+<template>
+  <section class="d-flex flex-column gap-2 mt-3">
+    <fieldset class="type-select">
+      <h2>Chart Type</h2>
+      <label for="bar-chart">
+        <input
+          id="bar-chart"
+          type="radio"
+          class="sr-only"
+          name="chart-type"
+          value="bar"
+          :checked="question_responses.type === 'bar'"
+          @change="
+            $emit('update:question_responses', {
+              ...question_responses,
+              type: 'bar',
+            })
+          "
+        />
+
+        <IconChartBar />
+        Bar Chart
+      </label>
+
+      <label for="scatter-chart">
+        <input
+          id="scatter-chart"
+          type="radio"
+          name="chart-type"
+          value="scatter"
+          class="sr-only"
+          :checked="question_responses.type === 'scatter'"
+          @change="
+            $emit('update:question_responses', {
+              ...question_responses,
+              type: 'scatter',
+            })
+          "
+        />
+        <IconChartScatter />
+        Scatter Plot
+      </label>
+    </fieldset>
+
+    <div class="row">
+      <label for="x-axis-label" class="col-form-label col-sm-3">
+        X Axis Label
+      </label>
+      <div class="col-sm-9">
+        <input
+          type="text"
+          class="form-control"
+          :value="question_responses.x_axis_label"
+          required
+          @input="
+            (event) =>
+              $emit('update:question_responses', {
+                ...question_responses,
+                x_axis_label: (event.target as HTMLInputElement).value,
+              })
+          "
+        />
+      </div>
+    </div>
+
+    <div v-if="question_responses.type === 'scatter'" class="row">
+      <label for="x-axis-label" class="col-form-label col-sm-3">
+        Y Axis Label
+      </label>
+      <div class="col-sm-9">
+        <input
+          type="text"
+          class="form-control"
+          :value="question_responses.y_axis_label"
+          :required="question_responses.type === 'scatter'"
+          @input="
+            (event) =>
+              $emit('update:question_responses', {
+                ...question_responses,
+                y_axis_label: (event.target as HTMLInputElement).value,
+              })
+          "
+        />
+      </div>
+    </div>
+  </section>
+</template>
+<script setup lang="ts">
+import VSelect from "@/components/VSelect.vue";
+import IconChartBar from "@/icons/IconChartBar.vue";
+import IconChartScatter from "@/icons/IconChartScatter.vue";
+
+interface NumericQuestionResponseOptions {
+  type: "bar" | "scatter";
+  x_axis_label: string;
+  y_axis_label: string;
+}
+
+withDefaults(
+  defineProps<{
+    // eslint-disable-next-line vue/prop-name-casing
+    question_responses: NumericQuestionResponseOptions;
+  }>(),
+  {
+    question_responses: () => ({
+      type: "bar",
+      x_axis_label: "",
+      y_axis_label: "",
+    }),
+  }
+);
+
+defineEmits<{
+  (event: "update:question_responses", value: NumericQuestionResponseOptions);
+}>();
+</script>
+<style scoped>
+.type-select {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.type-select h2 {
+  margin: 0;
+  font-size: 1rem;
+  width: 25%;
+}
+
+.type-select label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid #ced4da;
+  padding: 0.5rem;
+  border-radius: 4px;
+}
+
+.type-select label:has(input:checked) {
+  background-color: #333;
+  border-color: #333;
+  color: white;
+}
+</style>

--- a/resources/assets/js/views/QuestionForm/QuestionForm.vue
+++ b/resources/assets/js/views/QuestionForm/QuestionForm.vue
@@ -105,6 +105,7 @@ import FreeResponseQuestionOptions from "./FreeResponseQuestionOptions.vue";
 import TextHeatmapResponseQuestionOptions from "./TextHeatmapResponseQuestionOptions.vue";
 import HeatmapResponseQuestionOptions from "./HeatmapResponseQuestionOptions.vue";
 import NoResponseQuestionOptions from "./FreeResponseQuestionOptions.vue";
+import NumericResponseQuestionOptions from "./NumericResponseQuestionOptions.vue";
 import Modal from "../../components/Modal.vue";
 import VSelect from "../../components/VSelect.vue";
 import VEditor from "../../components/VEditor.vue";
@@ -118,6 +119,7 @@ export default {
     free_response_response: FreeResponseQuestionOptions,
     text_heatmap_response_response: TextHeatmapResponseQuestionOptions,
     heatmap_response_response: HeatmapResponseQuestionOptions,
+    numeric_response_response: NumericResponseQuestionOptions,
     no_response_response: NoResponseQuestionOptions,
     Modal,
   },
@@ -141,6 +143,10 @@ export default {
         {
           id: "free_response",
           label: "Free Response",
+        },
+        {
+          id: "numeric_response",
+          label: "Numeric",
         },
         {
           id: "slider_response",

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -236,3 +236,11 @@ img {
 ul {
   margin-bottom: 0;
 }
+
+.h-full {
+  height: 100%;
+}
+
+.min-h-full {
+  min-height: 100%;
+}


### PR DESCRIPTION
This adds a new "Numeric" question type gathering univariate or bivariate data and showing results as a histogram or scatter plot.

The histogram has configurable bucket size.
The scatter plot can optionally show regression lines (linear, quadratic, cubic, and exponential).

On dev for testing. Resolves #875. 

### Histogram

Question form:
<img src="https://github.com/user-attachments/assets/f9a6411f-d77a-48fc-971a-c64e5057fe7f" width="600" />

Participant input:
<img src="https://github.com/user-attachments/assets/e5e7f920-5c98-4c47-b495-1414378ccedb" width="600" />

Results with configurable bucket size:
<img src="https://github.com/user-attachments/assets/bbbb443d-5c38-48fd-8a48-6570394ff575" width="600" />


## Scatter Plot with Trendline

Question form:
<img src="https://github.com/user-attachments/assets/844e07dc-362c-47ec-b4b5-15d41ff8f5c9" width="600" />

Participant input:
<img src="https://github.com/user-attachments/assets/089e22f4-7e1f-4165-a0e5-9d1bc084d6c6" width="600" />

Scatter plot with trendline:
<img src="https://github.com/user-attachments/assets/3295e57d-0498-4886-9a8c-7fcab9af74ca" 
 width="600" />


