### PR TITLE
Add range chart

### DIFF
--- a/resources/assets/js/components/NumberInputGroup.vue
+++ b/resources/assets/js/components/NumberInputGroup.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="number-input-group">
+    <label :for="id">
+      {{ label }}
+    </label>
+    <input
+      :id="id"
+      :value="modelValue"
+      type="number"
+      :disabled="disabled"
+      class="form-control"
+      @input="handleInput"
+    />
+  </div>
+</template>
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    id: string;
+    label: string;
+    modelValue: number;
+    disabled?: boolean;
+  }>(),
+  {
+    disabled: false,
+  }
+);
+
+const emit = defineEmits<{
+  (eventName: "update:modelValue", value: number): void;
+}>();
+
+function handleInput(event: Event) {
+  const target = event.target as HTMLInputElement;
+
+  const x = parseFloat(target.value);
+
+  // ignore updates that are not numbers
+  if (isNaN(x)) {
+    return;
+  }
+
+  emit("update:modelValue", x);
+}
+</script>
+<style scoped></style>

--- a/resources/assets/js/components/NumericResponse/BarChartResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/BarChartResponseInputs.vue
@@ -1,0 +1,48 @@
+<template>
+  <div>
+    <label for="numeric-x-input" class="form-label">
+      {{ questionOptions.x_axis_label }}
+    </label>
+    <input
+      id="numeric-x-input"
+      :value="responseInfo.x"
+      type="number"
+      :disabled="disabled"
+      class="form-control"
+      @input="handleInput"
+    />
+  </div>
+</template>
+<script setup lang="ts">
+import {
+  NumericResponseResponseInfo,
+  NumericResponseQuestionInfo,
+} from "@/types";
+
+const props = defineProps<{
+  questionOptions: NumericResponseQuestionInfo["question_responses"];
+  disabled: boolean;
+  responseInfo: NumericResponseResponseInfo;
+}>();
+
+const emit = defineEmits<{
+  (eventName: "update:responseInfo", value: NumericResponseResponseInfo): void;
+}>();
+
+function handleInput(event: Event) {
+  const target = event.target as HTMLInputElement;
+
+  const x = parseFloat(target.value);
+
+  // ignore updates that are not numbers
+  if (isNaN(x)) {
+    return;
+  }
+
+  emit("update:responseInfo", {
+    ...props.responseInfo,
+    x,
+  });
+}
+</script>
+<style scoped></style>

--- a/resources/assets/js/components/NumericResponse/BarChartResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/BarChartResponseInputs.vue
@@ -2,7 +2,7 @@
   <NumInput
     :id="`numeric-x-input`"
     :label="questionOptions.x_axis_label"
-    :modelValue="responseInfo.x"
+    :modelValue="responseInfo.x ?? 0"
     @update:modelValue="
       $emit('update:responseInfo', { ...responseInfo, x: $event })
     "

--- a/resources/assets/js/components/NumericResponse/BarChartResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/BarChartResponseInputs.vue
@@ -1,48 +1,28 @@
 <template>
-  <div>
-    <label for="numeric-x-input" class="form-label">
-      {{ questionOptions.x_axis_label }}
-    </label>
-    <input
-      id="numeric-x-input"
-      :value="responseInfo.x"
-      type="number"
-      :disabled="disabled"
-      class="form-control"
-      @input="handleInput"
-    />
-  </div>
+  <NumInput
+    :id="`numeric-x-input`"
+    :label="questionOptions.x_axis_label"
+    :modelValue="responseInfo.x"
+    @update:modelValue="
+      $emit('update:responseInfo', { ...responseInfo, x: $event })
+    "
+  />
 </template>
 <script setup lang="ts">
+import NumInput from "@/components/NumberInputGroup.vue";
 import {
   NumericResponseResponseInfo,
   NumericResponseQuestionInfo,
 } from "@/types";
 
-const props = defineProps<{
+defineProps<{
   questionOptions: NumericResponseQuestionInfo["question_responses"];
   disabled: boolean;
   responseInfo: NumericResponseResponseInfo;
 }>();
 
-const emit = defineEmits<{
+defineEmits<{
   (eventName: "update:responseInfo", value: NumericResponseResponseInfo): void;
 }>();
-
-function handleInput(event: Event) {
-  const target = event.target as HTMLInputElement;
-
-  const x = parseFloat(target.value);
-
-  // ignore updates that are not numbers
-  if (isNaN(x)) {
-    return;
-  }
-
-  emit("update:responseInfo", {
-    ...props.responseInfo,
-    x,
-  });
-}
 </script>
 <style scoped></style>

--- a/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
@@ -1,26 +1,37 @@
 <template>
   <article>
-    <div class="mb-3 d-flex gap-3">
+    <BarChartResponseInputs
+      v-if="questionOptions.chart_type === 'bar'"
+      :questionOptions="questionOptions"
+      :disabled="disabled"
+      :responseInfo="localResponseInfo"
+      @update:responseInfo="localResponseInfo.x = $event.x"
+    />
+
+    <div
+      v-if="questionOptions.chart_type === 'scatter'"
+      class="mb-3 d-flex gap-3"
+    >
       <div>
         <label for="numeric-x-input" class="form-label">
           {{ questionOptions.x_axis_label }}
         </label>
         <input
           id="numeric-x-input"
-          v-model="localResponse.x"
+          v-model="localResponseInfo.x"
           type="number"
           :disabled="props.disabled"
           class="form-control"
         />
       </div>
 
-      <div v-if="questionOptions.chart_type === 'scatter'">
+      <div>
         <label for="numeric-y-input" class="form-label">
           {{ questionOptions.y_axis_label }}
         </label>
         <input
           id="numeric-y-input"
-          v-model="localResponse.y"
+          v-model="localResponseInfo.y"
           type="number"
           :disabled="disabled"
           class="form-control"
@@ -70,6 +81,7 @@ import {
 } from "@/types";
 import { isEmpty } from "ramda";
 import { computed, reactive, ref, watch } from "vue";
+import BarChartResponseInputs from "./BarChartResponseInputs.vue";
 
 const props = defineProps<{
   question: Question<NumericResponseQuestionInfo>;
@@ -81,7 +93,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (
     event: "recordresponse",
-    response: NumericResponseResponseInfo,
+    responseInfo: NumericResponseResponseInfo,
     // false = update, true = save as new
     createAsNewResponse?: boolean
   ): void;
@@ -99,17 +111,25 @@ const maybeResponse = computed(
 
 const hasExistingResponse = computed(() => !!maybeResponse.value?.id);
 
-const localResponse = reactive<NumericResponseResponseInfo>({
+const localResponseInfo = reactive<NumericResponseResponseInfo>({
   question_type: "numeric_response",
   x: 0,
   y: 0,
 });
 
 watch(
+  localResponseInfo,
+  () => {
+    console.log({ localResponseInfo });
+  },
+  { deep: true, immediate: true }
+);
+
+watch(
   maybeResponse,
   () => {
-    localResponse.x = maybeResponse.value?.response_info?.x ?? 0;
-    localResponse.y = maybeResponse.value?.response_info?.y ?? 0;
+    localResponseInfo.x = maybeResponse.value?.response_info?.x ?? 0;
+    localResponseInfo.y = maybeResponse.value?.response_info?.y ?? 0;
   },
   { immediate: true }
 );
@@ -119,18 +139,18 @@ const questionOptions = computed(() => {
 });
 
 function handleSave() {
-  emit("recordresponse", localResponse, true);
+  emit("recordresponse", localResponseInfo, true);
   hasStartedNewResponse.value = false;
 }
 
 function handleUpdate() {
-  emit("recordresponse", localResponse, false);
+  emit("recordresponse", localResponseInfo, false);
 }
 
 const hasStartedNewResponse = ref(false);
 function handleClearAndStartNewResponse() {
-  localResponse.x = 0;
-  localResponse.y = 0;
+  localResponseInfo.x = 0;
+  localResponseInfo.y = 0;
   hasStartedNewResponse.value = true;
 }
 </script>

--- a/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
@@ -8,37 +8,23 @@
         :responseInfo="localResponseInfo"
         @update:responseInfo="localResponseInfo.x = $event.x"
       />
-    </div>
-
-    <div
-      v-if="questionOptions.chart_type === 'scatter'"
-      class="mb-3 d-flex gap-3"
-    >
-      <div>
-        <label for="numeric-x-input" class="form-label">
-          {{ questionOptions.x_axis_label }}
-        </label>
-        <input
-          id="numeric-x-input"
-          v-model="localResponseInfo.x"
-          type="number"
-          :disabled="props.disabled"
-          class="form-control"
-        />
-      </div>
-
-      <div>
-        <label for="numeric-y-input" class="form-label">
-          {{ questionOptions.y_axis_label }}
-        </label>
-        <input
-          id="numeric-y-input"
-          v-model="localResponseInfo.y"
-          type="number"
-          :disabled="disabled"
-          class="form-control"
-        />
-      </div>
+      <ScatterPlotResponseInputs
+        v-else-if="questionOptions.chart_type === 'scatter'"
+        :questionOptions="questionOptions"
+        :disabled="disabled"
+        :responseInfo="localResponseInfo"
+        @update:responseInfo="
+          localResponseInfo.x = $event.x;
+          localResponseInfo.y = $event.y;
+        "
+      />
+      <RangeChartResponseInputs
+        v-else-if="questionOptions.chart_type === 'range'"
+        :questionOptions="questionOptions"
+        :disabled="disabled"
+        :responseInfo="localResponseInfo"
+        @update:responseInfo="localResponseInfo.xRange = $event.xRange"
+      />
     </div>
     <div class="mb-3 d-flex gap-2">
       <button
@@ -84,6 +70,8 @@ import {
 import { isEmpty } from "ramda";
 import { computed, reactive, ref, watch } from "vue";
 import BarChartResponseInputs from "./BarChartResponseInputs.vue";
+import ScatterPlotResponseInputs from "./ScatterPlotResponseInputs.vue";
+import RangeChartResponseInputs from "./RangeChartResponseInputs.vue";
 
 const props = defineProps<{
   question: Question<NumericResponseQuestionInfo>;
@@ -117,6 +105,7 @@ const localResponseInfo = reactive<NumericResponseResponseInfo>({
   question_type: "numeric_response",
   x: 0,
   y: 0,
+  xRange: [0, 0],
 });
 
 watch(

--- a/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
@@ -1,12 +1,14 @@
 <template>
   <article>
-    <BarChartResponseInputs
-      v-if="questionOptions.chart_type === 'bar'"
-      :questionOptions="questionOptions"
-      :disabled="disabled"
-      :responseInfo="localResponseInfo"
-      @update:responseInfo="localResponseInfo.x = $event.x"
-    />
+    <div class="mb-3">
+      <BarChartResponseInputs
+        v-if="questionOptions.chart_type === 'bar'"
+        :questionOptions="questionOptions"
+        :disabled="disabled"
+        :responseInfo="localResponseInfo"
+        @update:responseInfo="localResponseInfo.x = $event.x"
+      />
+    </div>
 
     <div
       v-if="questionOptions.chart_type === 'scatter'"

--- a/resources/assets/js/components/NumericResponse/RangeChart.vue
+++ b/resources/assets/js/components/NumericResponse/RangeChart.vue
@@ -19,6 +19,15 @@
     >
       No data
     </p>
+
+    <GChart
+      v-if="data.length"
+      type="Table"
+      :data="[
+        ['Response', 'Min', 'Max'],
+        ...data.map(([min, max], index) => [index + 1, min, max]),
+      ]"
+    />
   </div>
 </template>
 <script setup lang="ts">

--- a/resources/assets/js/components/NumericResponse/RangeChart.vue
+++ b/resources/assets/js/components/NumericResponse/RangeChart.vue
@@ -1,7 +1,5 @@
 <template>
   <div class="">
-    {{ data }}
-
     <GChart
       v-if="data.length"
       type="BarChart"
@@ -63,29 +61,32 @@ const chartData = computed(() => {
     ...props.data.map(([minX, maxX], index) => {
       const diff = maxX - minX;
 
+      const tooltip = `[${index + 1}] min: ${minX}, max: ${maxX}, Δ: ${diff}`;
+      const label = index + 1;
+
       // Case 1: 0 < minX < maxX
       if (minX >= 0) {
         return [
-          index.toString(),
+          label,
           minX,
           "opacity: 0",
-          `min: ${minX}`,
+          tooltip,
           diff,
           "opacity: 1",
-          `max: ${maxX}`,
+          tooltip,
         ];
       }
 
       // Case 2: minX < 0 < maxX
       if (minX < 0 && maxX >= 0) {
         return [
-          index.toString(),
+          label,
           minX,
           "opacity: 1",
-          `min: ${minX}`,
+          tooltip,
           maxX,
           "opacity: 1",
-          `max: ${maxX}`,
+          tooltip,
         ];
       }
 
@@ -95,15 +96,15 @@ const chartData = computed(() => {
         // we FIRST draw the transparent bar to the max
         // and THEN draw the diff
         return [
-          index.toString(),
+          label,
           maxX,
           "opacity: 0",
-          `max: ${maxX}`,
+          tooltip,
           // diff needs to be negated so that it's drawn
           // in the negative direction
           -1 * diff,
           "opacity: 1",
-          `min: ${minX}`,
+          tooltip,
         ];
       }
     }),

--- a/resources/assets/js/components/NumericResponse/RangeChart.vue
+++ b/resources/assets/js/components/NumericResponse/RangeChart.vue
@@ -1,0 +1,150 @@
+<template>
+  <div class="">
+    {{ data }}
+
+    <GChart
+      v-if="data.length"
+      type="BarChart"
+      :data="chartData"
+      :options="chartOptions"
+      class="googleChart"
+    />
+    <p
+      v-else
+      style="
+        display: grid;
+        min-height: 10em;
+        place-content: center;
+        background: #fafafa;
+        border-radius: 0.5rem;
+      "
+    >
+      No data
+    </p>
+  </div>
+</template>
+<script setup lang="ts">
+import { GChart } from "vue-google-charts";
+import { computed } from "vue";
+
+const props = defineProps<{
+  data: [minX: number, maxX: number][];
+  xAxisLabel: string;
+}>();
+
+const chartData = computed(() => {
+  const header = [
+    "Label",
+    "Min",
+    { role: "style" },
+    { role: "tooltip" },
+    "Max",
+    { role: "style" },
+    { role: "tooltip" },
+  ];
+
+  /**
+   * The magic behind the range chart is that
+   * we're drawing stacked bars, where one is transparent
+   * and the other is the diff between the min and max.
+   *
+   * We need to handle three cases:
+   * 1. 0 < minX < maxX - draw a transparent bar to minX,
+   *    then draw the diff normally.
+   * 2. minX < 0 < maxX - both bars normally – no transparent bar needed.
+   * 3. minX < maxX < 0 - draw a transparent bar to maxX,
+   *   then draw the (negative) diff normally.
+   *
+   * We also need to customize the tooltips to show the
+   * proper min and max values, and not the diff.
+   */
+  return [
+    header,
+    ...props.data.map(([minX, maxX], index) => {
+      const diff = maxX - minX;
+
+      // Case 1: 0 < minX < maxX
+      if (minX >= 0) {
+        return [
+          index.toString(),
+          minX,
+          "opacity: 0",
+          `min: ${minX}`,
+          diff,
+          "opacity: 1",
+          `max: ${maxX}`,
+        ];
+      }
+
+      // Case 2: minX < 0 < maxX
+      if (minX < 0 && maxX >= 0) {
+        return [
+          index.toString(),
+          minX,
+          "opacity: 1",
+          `min: ${minX}`,
+          maxX,
+          "opacity: 1",
+          `max: ${maxX}`,
+        ];
+      }
+
+      // Case 3: minX < maxX < 0
+      if (maxX < 0) {
+        // we need to swap the draw order so that
+        // we FIRST draw the transparent bar to the max
+        // and THEN draw the diff
+        return [
+          index.toString(),
+          maxX,
+          "opacity: 0",
+          `max: ${maxX}`,
+          // diff needs to be negated so that it's drawn
+          // in the negative direction
+          -1 * diff,
+          "opacity: 1",
+          `min: ${minX}`,
+        ];
+      }
+    }),
+  ];
+});
+
+const chartOptions = computed(() => {
+  return {
+    isStacked: true,
+    hAxis: {
+      title: props.xAxisLabel,
+    },
+    vAxis: {
+      title: "Responses",
+    },
+    animation: {
+      duration: 1000,
+      easing: "out",
+      startup: true,
+    },
+    legend: {
+      position: "none",
+    },
+    chartArea: {
+      top: 30,
+      left: 50,
+      width: "100%",
+    },
+    tooltip: {
+      isHtml: false,
+    },
+    bar: { groupWidth: "95%" },
+    series: {
+      0: { color: "#36C" },
+      1: { color: "#36C" },
+    },
+  };
+});
+</script>
+<style scoped>
+.googleChart {
+  min-height: 600px;
+}
+</style>

--- a/resources/assets/js/components/NumericResponse/RangeChartResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/RangeChartResponseInputs.vue
@@ -1,0 +1,59 @@
+<template>
+  <div>
+    <p class="mb-0">
+      {{ questionOptions.x_axis_label }}
+    </p>
+    <div class="d-flex gap-3">
+      <NumInput
+        id="range-min"
+        label="Min"
+        :modelValue="currentMin"
+        :disabled="disabled"
+        @update:modelValue="updateMin"
+      />
+      <NumInput
+        id="range-max"
+        label="Max"
+        :modelValue="responseInfo?.xRange?.[1] ?? 0"
+        :disabled="disabled"
+        @update:modelValue="updateMax"
+      />
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+import NumInput from "@/components/NumberInputGroup.vue";
+import {
+  NumericResponseResponseInfo,
+  NumericResponseQuestionInfo,
+} from "@/types";
+import { computed } from "vue";
+
+const props = defineProps<{
+  questionOptions: NumericResponseQuestionInfo["question_responses"];
+  disabled: boolean;
+  responseInfo: Pick<NumericResponseResponseInfo, "question_type" | "xRange">;
+}>();
+
+const emit = defineEmits<{
+  (eventName: "update:responseInfo", value: NumericResponseResponseInfo): void;
+}>();
+
+const currentMin = computed(() => props.responseInfo.xRange?.[0] ?? 0);
+const currentMax = computed(() => props.responseInfo.xRange?.[1] ?? 0);
+
+function updateMin(value: number) {
+  emit("update:responseInfo", {
+    ...props.responseInfo,
+    xRange: [value, currentMax.value],
+  });
+}
+
+function updateMax(value: number) {
+  emit("update:responseInfo", {
+    ...props.responseInfo,
+    xRange: [currentMin.value, value],
+  });
+}
+</script>
+<style scoped></style>

--- a/resources/assets/js/components/NumericResponse/ScatterPlotResponseInput.vue
+++ b/resources/assets/js/components/NumericResponse/ScatterPlotResponseInput.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="d-flex gap-3">
+    <NumInput
+      id="numeric-x-input"
+      :label="questionOptions.x_axis_label"
+      :modelValue="responseInfo.x"
+      :disabled="disabled"
+      @update:modelValue="
+        $emit('update:responseInfo', { ...responseInfo, x: $event })
+      "
+    />
+    <NumInput
+      id="numeric-y-input"
+      :label="questionOptions.y_axis_label ?? 'Y'"
+      :modelValue="responseInfo.y"
+      :disabled="disabled"
+      @update:modelValue="
+        $emit('update:responseInfo', { ...responseInfo, y: $event })
+      "
+    />
+  </div>
+</template>
+<script setup lang="ts">
+import NumInput from "@/components/NumberInputGroup.vue";
+import {
+  NumericResponseResponseInfo,
+  NumericResponseQuestionInfo,
+} from "@/types";
+
+defineProps<{
+  questionOptions: NumericResponseQuestionInfo["question_responses"];
+  disabled: boolean;
+  responseInfo: NumericResponseResponseInfo;
+}>();
+
+defineEmits<{
+  (eventName: "update:responseInfo", value: NumericResponseResponseInfo): void;
+}>();
+</script>
+<style scoped></style>

--- a/resources/assets/js/components/NumericResponse/ScatterPlotResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/ScatterPlotResponseInputs.vue
@@ -3,7 +3,7 @@
     <NumInput
       id="numeric-x-input"
       :label="questionOptions.x_axis_label"
-      :modelValue="responseInfo.x"
+      :modelValue="responseInfo.x ?? 0"
       :disabled="disabled"
       @update:modelValue="
         $emit('update:responseInfo', { ...responseInfo, x: $event })
@@ -12,7 +12,7 @@
     <NumInput
       id="numeric-y-input"
       :label="questionOptions.y_axis_label ?? 'Y'"
-      :modelValue="responseInfo.y"
+      :modelValue="responseInfo.y ?? 0"
       :disabled="disabled"
       @update:modelValue="
         $emit('update:responseInfo', { ...responseInfo, y: $event })

--- a/resources/assets/js/icons/IconChartRange.vue
+++ b/resources/assets/js/icons/IconChartRange.vue
@@ -1,0 +1,52 @@
+<template>
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 256 256"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle cx="69.3092" cy="53.31" r="20.6819" fill="currentColor" />
+    <circle cx="69.3092" cy="148.74" r="20.6819" fill="currentColor" />
+    <rect
+      x="58.968"
+      y="54.3996"
+      width="20.6819"
+      height="94.3404"
+      rx="10.3409"
+      fill="currentColor"
+    />
+    <circle cx="128" cy="104.469" r="20.6819" fill="currentColor" />
+    <circle cx="128" cy="188.276" r="20.6819" fill="currentColor" />
+    <rect
+      x="117.659"
+      y="101.025"
+      width="20.6819"
+      height="87.3507"
+      rx="10.3409"
+      fill="currentColor"
+    />
+    <circle cx="186.691" cy="156.496" r="20.6819" fill="currentColor" />
+    <circle cx="186.691" cy="46.5086" r="20.6819" fill="currentColor" />
+    <rect
+      x="176.35"
+      y="40.6864"
+      width="20.6819"
+      height="121.86"
+      rx="10.3409"
+      fill="currentColor"
+    />
+    <rect
+      x="25.2252"
+      y="217.916"
+      width="205.549"
+      height="8"
+      rx="4"
+      fill="currentColor"
+    />
+  </svg>
+</template>
+<script lang="ts">
+export default {
+  name: "IconChartRange",
+};
+</script>

--- a/resources/assets/js/icons/IconChartRange.vue
+++ b/resources/assets/js/icons/IconChartRange.vue
@@ -5,42 +5,58 @@
     viewBox="0 0 256 256"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <circle cx="69.3092" cy="53.31" r="20.6819" fill="currentColor" />
-    <circle cx="69.3092" cy="148.74" r="20.6819" fill="currentColor" />
     <rect
-      x="58.968"
-      y="54.3996"
+      x="24.9953"
+      y="209.551"
       width="20.6819"
-      height="94.3404"
+      height="134.522"
       rx="10.3409"
+      transform="rotate(-90 24.9953 209.551)"
       fill="currentColor"
     />
-    <circle cx="128" cy="104.469" r="20.6819" fill="currentColor" />
-    <circle cx="128" cy="188.276" r="20.6819" fill="currentColor" />
     <rect
-      x="117.659"
-      y="101.025"
+      x="91.4036"
+      y="173.946"
+      width="20.6819"
+      height="136.228"
+      rx="10.3409"
+      transform="rotate(-90 91.4036 173.946)"
+      fill="currentColor"
+    />
+    <rect
+      x="62.0968"
+      y="67.1312"
       width="20.6819"
       height="87.3507"
       rx="10.3409"
+      transform="rotate(-90 62.0968 67.1312)"
       fill="currentColor"
     />
-    <circle cx="186.691" cy="156.496" r="20.6819" fill="currentColor" />
-    <circle cx="186.691" cy="46.5086" r="20.6819" fill="currentColor" />
     <rect
-      x="176.35"
-      y="40.6864"
+      x="140.281"
+      y="102.736"
       width="20.6819"
-      height="121.86"
+      height="87.3507"
       rx="10.3409"
+      transform="rotate(-90 140.281 102.736)"
       fill="currentColor"
     />
     <rect
-      x="25.2252"
-      y="217.916"
-      width="205.549"
-      height="8"
+      x="62.0968"
+      y="138.341"
+      width="20.6819"
+      height="97.4209"
+      rx="10.3409"
+      transform="rotate(-90 62.0968 138.341)"
+      fill="currentColor"
+    />
+    <rect
+      x="128"
+      y="222.916"
+      width="8"
+      height="189.832"
       rx="4"
+      transform="rotate(-180 128 222.916)"
       fill="currentColor"
     />
   </svg>

--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -207,10 +207,12 @@ export interface PinOnImageQuestionInfo extends QuestionInfo {
   };
 }
 
+export type NumericChartType = "bar" | "scatter" | "range";
+
 export interface NumericResponseQuestionInfo extends QuestionInfo {
   question_type: "numeric_response";
   question_responses: {
-    chart_type: "bar" | "scatter" | "range";
+    chart_type: NumericChartType;
     x_axis_label: string;
     y_axis_label?: string; // only for scatter
   };

--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -208,7 +208,7 @@ export interface PinOnImageQuestionInfo extends QuestionInfo {
 export interface NumericResponseQuestionInfo extends QuestionInfo {
   question_type: "numeric_response";
   question_responses: {
-    chart_type: "bar" | "scatter";
+    chart_type: "bar" | "scatter" | "range";
     x_axis_label: string;
     y_axis_label?: string; // only for scatter
   };

--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -88,8 +88,10 @@ export interface PinOnImageResponseResponseInfo extends ResponseInfo {
 
 export interface NumericResponseResponseInfo extends ResponseInfo {
   question_type: "numeric_response";
-  x: number;
-  y: number;
+  x?: number;
+  y?: number;
+  xRange?: [number, number];
+  yRange?: [number, number];
 }
 
 export type MultipleChoiceResponse = Response<MultipleChoiceResponseInfo>;

--- a/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
@@ -12,11 +12,17 @@
       :xAxisLabel="questionOptions.x_axis_label || 'X'"
       :yAxisLabel="questionOptions.y_axis_label || 'Y'"
     />
+    <RangeChart
+      v-else-if="chartType === 'range'"
+      :data="rangeChartData"
+      :xAxisLabel="questionOptions.x_axis_label"
+    />
   </div>
 </template>
 <script setup lang="ts">
 import BarChart from "@/components/NumericResponse/BarChart.vue";
 import ScatterPlot from "@/components/NumericResponse/ScatterPlot.vue";
+import RangeChart from "@/components/NumericResponse/RangeChart.vue";
 import type {
   NumericResponseResponseInfo,
   NumericResponseQuestionInfo,
@@ -46,15 +52,25 @@ const barChartData = computed((): [label: string, value: number][] => {
       ? `Response ${index + 1}`
       : response.user.name;
 
-    return [label, response.response_info.x];
+    return [label, response.response_info.x ?? 0];
   });
 });
 
 const scatterPlotData = computed((): [x: number, y: number][] => {
   return props.responses.map((response) => [
-    response.response_info.x,
-    response.response_info.y,
+    response.response_info.x ?? 0,
+    response.response_info.y ?? 0,
   ]);
+});
+
+const rangeChartData = computed((): [minX: number, maxX: number][] => {
+  return props.responses.map((response) => {
+    const a = response.response_info.xRange?.[0] ?? 0;
+    const b = response.response_info.xRange?.[1] ?? 0;
+    const min = Math.min(a, b);
+    const max = Math.max(a, b);
+    return [min, max];
+  });
 });
 </script>
 <style scoped></style>

--- a/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
+++ b/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
@@ -37,7 +37,7 @@
           "
         />
         <IconChartScatter />
-        Scatter Plot
+        Scatter
       </label>
 
       <label for="range-chart">
@@ -56,7 +56,7 @@
           "
         />
         <IconChartRange />
-        Range Chart
+        Range
       </label>
     </fieldset>
 

--- a/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
+++ b/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
@@ -21,7 +21,6 @@
         <IconChartBar />
         Histogram
       </label>
-
       <label for="scatter-chart">
         <input
           id="scatter-chart"
@@ -39,6 +38,25 @@
         />
         <IconChartScatter />
         Scatter Plot
+      </label>
+
+      <label for="range-chart">
+        <input
+          id="range-chart"
+          type="radio"
+          name="chart-type"
+          value="range"
+          class="sr-only"
+          :checked="typedQuestionResponsesProp.chart_type === 'range'"
+          @change="
+            $emit('update:question_responses', {
+              ...typedQuestionResponsesProp,
+              chart_type: 'range',
+            })
+          "
+        />
+        <IconChartRange />
+        Range Chart
       </label>
     </fieldset>
 
@@ -88,6 +106,7 @@
 <script setup lang="ts">
 import IconChartBar from "@/icons/IconChartBar.vue";
 import IconChartScatter from "@/icons/IconChartScatter.vue";
+import IconChartRange from "@/icons/IconChartRange.vue";
 import { NumericResponseQuestionInfo } from "@/types";
 import { computed } from "vue";
 
@@ -140,7 +159,8 @@ const typedQuestionResponsesProp = computed(() => {
 </script>
 <style scoped>
 .type-select {
-  display: flex;
+  display: grid;
+  grid-template-columns: 25% repeat(3, 1fr);
   align-items: baseline;
   gap: 0.5rem;
 }
@@ -148,7 +168,6 @@ const typedQuestionResponsesProp = computed(() => {
 .type-select h2 {
   margin: 0;
   font-size: 1rem;
-  width: 25%;
 }
 
 .type-select label {
@@ -158,6 +177,7 @@ const typedQuestionResponsesProp = computed(() => {
   border: 1px solid #ced4da;
   padding: 0.5rem;
   border-radius: 4px;
+  font-size: 0.875rem;
 }
 
 .type-select label:has(input:checked) {


### PR DESCRIPTION
Adds a option for numeric response to show a range chart.

<img src="https://github.com/user-attachments/assets/8b7ef259-eaff-4a50-a60f-119ebacbd887" width="500" />

Previously there was a question of whether or not it'd be better to type the chart something more abstract like "univariate"/"bivariate". After this, my sense is that it's better to handle charts on case by basis.

Here, a range question (e.g. "Estimate how much building the thing will cost?") is univariate so we only need one variable label from the question form – like other univariate data. But, on the user form, we gather two numbers min and max (`xRange`), which differs from the the other univariate histogram question (where we only ask the user for 1 number).

On dev for testing.