### PR TITLE
add middleware to prevent json payloads over 10kb

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -56,6 +56,7 @@ class Kernel extends HttpKernel {
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
-        'shibinjection' => \App\Http\Middleware\ShibInjection::class
+        'shibinjection' => \App\Http\Middleware\ShibInjection::class,
+        'limit.json.size'  => \App\Http\Middleware\LimitJsonSize::class,
     ];
 }

--- a/app/Http/Middleware/LimitJsonSize.php
+++ b/app/Http/Middleware/LimitJsonSize.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class LimitJsonSize
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, ?int $maxSize = 10240): Response
+    {
+        $requestSize = strlen($request->getContent());
+
+        if ($request->isJson() && $requestSize > $maxSize) {
+            return response()->json([
+                'message' => 'The JSON data must not be larger than'
+                    . ($maxSize / 1024) . 'KB.'
+            ], 413);
+        }
+
+        return $next($request);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -79,7 +79,8 @@ Route::group(['middleware' => ['shibinjection']], function () {
     // Response subroutes
     Route::get('/api/chime/{chime_id}/responses', 'ResponseController@getResponse');
     Route::get('/api/chime/{chime_id}/session/{session_id}/question', 'ResponseController@getQuestion');
-    Route::put('/api/chime/{chime}/session/{session}/response/{response?}', 'ResponseController@createOrUpdateResponse');
+    Route::put('/api/chime/{chime}/session/{session}/response/{response?}', 'ResponseController@createOrUpdateResponse')
+        ->middleware('limit.json.size');
 
     Route::post('/api/chime/{chime}/folder/{folder}/question/startAll', 'PresentController@startAllQuestions');
     Route::put('/api/chime/{chime}/folder/{folder}/question/stopAll', 'PresentController@stopAllQuestions');
@@ -88,10 +89,13 @@ Route::group(['middleware' => ['shibinjection']], function () {
     // TODO: Change `includeQuestions to a query string param 
     // `include_questions=true`
     Route::get('/api/chime/{chime}/folder/{folder}/{includeQuestions?}',  'FolderController@show');
-    Route::post('/api/chime/{chime_id}/folder/{folder_id}', 'FolderController@createQuestion');
-    Route::post('/api/chime/{chime}/folder/{folder}/import', 'FolderController@importQuestions');
+    Route::post('/api/chime/{chime_id}/folder/{folder_id}', 'FolderController@createQuestion')
+        ->middleware('limit.json.size');
+    Route::post('/api/chime/{chime}/folder/{folder}/import', 'FolderController@importQuestions')
+        ->middleware('limit.json.size');
     Route::post('/api/chime/{chime}/folder/{folder}/sync', 'FolderController@forceSync');
-    Route::put('/api/chime/{chime_id}/folder/{folder_id}/question/{question_id}', 'FolderController@updateQuestion');
+    Route::put('/api/chime/{chime_id}/folder/{folder_id}/question/{question_id}', 'FolderController@updateQuestion')
+        ->middleware('limit.json.size');
     Route::put('/api/chime/{chime_id}/folder/{folder_id}/save_order', 'FolderController@saveOrder');
     Route::delete('/api/chime/{chime_id}/folder/{folder_id}/question/{question_id}', 'FolderController@deleteQuestion');
     Route::delete('/api/chime/{chime}/folder/{folder}/question/{question}/responses', 'FolderController@resetQuestion');


### PR DESCRIPTION
- creates a middleware for checking json payload size. Default max is 10kb.
- limits json payload size when:
   1. creating / updating questions
   2. creating/updating responses
   3. importing questions (wasn't sure about this one)
   
resolves #902 