### PR TITLE
fix: Image Resize Controls don't hide when clicking away

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@umn-latis/cla-vue-template": "^1.1.0",
-        "@umn-latis/quill-better-image-module": "^0.2.1",
+        "@umn-latis/quill-better-image-module": "^0.2.2",
         "@vue-a11y/announcer": "^3.1.5",
         "axios": "^1.6",
         "bootstrap": "^4.6.0",
@@ -2661,9 +2661,9 @@
       }
     },
     "node_modules/@umn-latis/quill-better-image-module": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@umn-latis/quill-better-image-module/-/quill-better-image-module-0.2.1.tgz",
-      "integrity": "sha512-uMjxUj6YyxjyNLDtNjNisoQLlIMF6+waXTM7dYJAJS6hCp7u0q+/UXRPfROIrJWGbRnzFo4Uiw9anFVj9hET7Q==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@umn-latis/quill-better-image-module/-/quill-better-image-module-0.2.2.tgz",
+      "integrity": "sha512-pNvfEya2BUGUyc/n/UPd6GsbvYB6qe1s0EJB616fyFqYlhXCmn0jhw/5Sfyvh613NHIjSR8iyOgdiXpkF0e1hw==",
       "dependencies": {
         "deepmerge": "^4.3.1",
         "deepmerge-ts": "^7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@umn-latis/cla-vue-template": "^1.1.0",
-        "@umn-latis/quill-better-image-module": "^0.2.0",
+        "@umn-latis/quill-better-image-module": "^0.2.1",
         "@vue-a11y/announcer": "^3.1.5",
         "axios": "^1.6",
         "bootstrap": "^4.6.0",
@@ -2661,9 +2661,9 @@
       }
     },
     "node_modules/@umn-latis/quill-better-image-module": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@umn-latis/quill-better-image-module/-/quill-better-image-module-0.2.0.tgz",
-      "integrity": "sha512-uszpHlrqCHP0hnyHt3zeMLfWgHshh2IGeExgjSrgmYwF+P8vIPE4XBFDSzFAu898u1oTVQSrshW8pE9DzglfOw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@umn-latis/quill-better-image-module/-/quill-better-image-module-0.2.1.tgz",
+      "integrity": "sha512-uMjxUj6YyxjyNLDtNjNisoQLlIMF6+waXTM7dYJAJS6hCp7u0q+/UXRPfROIrJWGbRnzFo4Uiw9anFVj9hET7Q==",
       "dependencies": {
         "deepmerge": "^4.3.1",
         "deepmerge-ts": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@popperjs/core": "^2.11.8",
     "@umn-latis/cla-vue-template": "^1.1.0",
-    "@umn-latis/quill-better-image-module": "^0.2.0",
+    "@umn-latis/quill-better-image-module": "^0.2.1",
     "@vue-a11y/announcer": "^3.1.5",
     "axios": "^1.6",
     "bootstrap": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@popperjs/core": "^2.11.8",
     "@umn-latis/cla-vue-template": "^1.1.0",
-    "@umn-latis/quill-better-image-module": "^0.2.1",
+    "@umn-latis/quill-better-image-module": "^0.2.2",
     "@vue-a11y/announcer": "^3.1.5",
     "axios": "^1.6",
     "bootstrap": "^4.6.0",


### PR DESCRIPTION
fix added to: https://github.com/UMN-LATIS/quill-better-image-module/commit/151cbd57d941151cb0684156ca01c85f37b1caaa

closes #428 

![ScreenShot 2024-09-09 at 17 04 13](https://github.com/user-attachments/assets/53ee5ddf-1797-4f72-8001-dce69218a617)



