### PR TITLE
Add impersonation banner with "Leave Impersonation" button

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,19 +2,20 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-use App\Chime;
 use Auth;
-use Illuminate\Support\Facades\Cookie;
+use Illuminate\Http\Request;
+use Laravel\Nova\Contracts\ImpersonatesUsers;
 
 class HomeController extends Controller
 {
 
-    public function index(Request $req)
+    public function index(Request $request, ImpersonatesUsers $impersonator)
     {
-        return view('app', ['user' => $req->user()]);
-    }
+        $user = $request->user();
+        $user->isImpersonated = $impersonator->impersonating($request);
 
+        return view('app', ['user' => $user]);
+    }
 
     // call this URL with target=<target> to force a login and redirect
     public function loginAndRedirect(Request $req)

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -4,17 +4,13 @@ namespace App\Http\Controllers;
 
 use Auth;
 use Illuminate\Http\Request;
-use Laravel\Nova\Contracts\ImpersonatesUsers;
 
 class HomeController extends Controller
 {
 
-    public function index(Request $request, ImpersonatesUsers $impersonator)
+    public function index(Request $request)
     {
-        $user = $request->user();
-        $user->isImpersonated = $impersonator->impersonating($request);
-
-        return view('app', ['user' => $user]);
+        return view('app', ['user' => $request->user()]);
     }
 
     // call this URL with target=<target> to force a login and redirect

--- a/app/Http/Controllers/ImpersonateController.php
+++ b/app/Http/Controllers/ImpersonateController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Nova\Contracts\ImpersonatesUsers;
+
+class ImpersonateController extends Controller
+{
+    public function stop(Request $request, ImpersonatesUsers $impersonator)
+    {
+        if ($impersonator->impersonating($request)) {
+            $impersonator->stopImpersonating($request, Auth::guard(), User::class);
+        }
+
+        return redirect()->route('home');
+    }
+}

--- a/app/Http/Middleware/ShibInjection.php
+++ b/app/Http/Middleware/ShibInjection.php
@@ -17,9 +17,10 @@ class ShibInjection
      */
     public function handle($request, Closure $next)
     {
+        Auth::user()->isImpersonated = app(ImpersonatesUsers::class)->impersonating($request);
+        
         // skip shib injection if we're impersonating
-        $impersonator = app(ImpersonatesUsers::class);
-        if ($impersonator->impersonating($request)) {
+        if (Auth::user()->isImpersonated) {
             return $next($request);
         }
 

--- a/app/Http/Middleware/ShibInjection.php
+++ b/app/Http/Middleware/ShibInjection.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Auth;
+use Laravel\Nova\Contracts\ImpersonatesUsers;
 
 class ShibInjection
 {
@@ -16,6 +17,12 @@ class ShibInjection
      */
     public function handle($request, Closure $next)
     {
+        // skip shib injection if we're impersonating
+        $impersonator = app(ImpersonatesUsers::class);
+        if ($impersonator->impersonating($request)) {
+            return $next($request);
+        }
+
         foreach (config('shibboleth.user') as $local => $server) {
             $map[$local] = $this->getServerVariable($server);
         }

--- a/app/Http/Middleware/ShibInjection.php
+++ b/app/Http/Middleware/ShibInjection.php
@@ -26,15 +26,6 @@ class ShibInjection
             }
         }
 
-        $manager = app('impersonate');
-        if($manager->isImpersonating()) {
-            Auth::user()->impersonating = true;
-        }
-        else {
-            Auth::user()->impersonating = false;
-        }
-
-        // dd(Auth::user());
         return $next($request);
     }
 

--- a/app/User.php
+++ b/app/User.php
@@ -5,6 +5,7 @@ namespace App;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Laravel\Nova\Auth\Impersonatable;
 use Yadahan\AuthenticationLog\AuthenticationLogable;
 
 class User extends Authenticatable
@@ -12,7 +13,7 @@ class User extends Authenticatable
     use HasFactory;
     use Notifiable;
     use AuthenticationLogable;
-    use \Lab404\Impersonate\Models\Impersonate;
+    use Impersonatable;
 
     /**
      * The attributes that are mass assignable.

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
     "fakerphp/faker": "^1.19",
     "imsglobal/lti": "dev-master",
     "intervention/image": "^2.4",
-    "lab404/laravel-impersonate": "^1.7",
     "laravel/framework": "^10.0",
     "laravel/helpers": "^1.4",
     "laravel/tinker": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ba9745b5e68dada629492188e093977",
+    "content-hash": "48773c3dc970b4350a29a38350847359",
     "packages": [
         {
             "name": "brick/math",
@@ -2005,73 +2005,6 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.0.6"
             },
             "time": "2024-03-08T09:58:59+00:00"
-        },
-        {
-            "name": "lab404/laravel-impersonate",
-            "version": "1.7.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/404labfr/laravel-impersonate.git",
-                "reference": "82cad73700a8699d63de169bb41abd5ae283e9a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/404labfr/laravel-impersonate/zipball/82cad73700a8699d63de169bb41abd5ae283e9a8",
-                "reference": "82cad73700a8699d63de169bb41abd5ae283e9a8",
-                "shasum": ""
-            },
-            "require": {
-                "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0",
-                "php": "^7.2 | ^8.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^1.3.3",
-                "orchestra/testbench": "^4.0 | ^5.0 | ^6.0 | ^7.0 | ^8.0 | ^9.0",
-                "phpunit/phpunit": "^7.5 | ^8.0 | ^9.0 | ^10.0"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Lab404\\Impersonate\\ImpersonateServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/helpers.php"
-                ],
-                "psr-4": {
-                    "Lab404\\Impersonate\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marceau Casals",
-                    "email": "marceau@casals.fr"
-                }
-            ],
-            "description": "Laravel Impersonate is a plugin that allows to you to authenticate as your users.",
-            "keywords": [
-                "auth",
-                "impersonate",
-                "impersonation",
-                "laravel",
-                "laravel-package",
-                "laravel-plugin",
-                "package",
-                "plugin",
-                "user"
-            ],
-            "support": {
-                "issues": "https://github.com/404labfr/laravel-impersonate/issues",
-                "source": "https://github.com/404labfr/laravel-impersonate/tree/1.7.5"
-            },
-            "time": "2024-03-11T14:26:14+00:00"
         },
         {
             "name": "laravel/framework",

--- a/config/app.php
+++ b/config/app.php
@@ -181,7 +181,6 @@ return [
 
         StudentAffairsUwm\Shibboleth\ShibbolethServiceProvider::class,
         StudentAffairsUwm\Shibboleth\ShibalikeServiceProvider::class,
-        Lab404\Impersonate\ImpersonateServiceProvider::class,
     ],
 
     /*

--- a/resources/assets/js/components/ImpersonationBanner.vue
+++ b/resources/assets/js/components/ImpersonationBanner.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="impersonation-banner tw-bg-pink-500 tw-text-pink-100">
+    <div
+      class="tw-max-w-[90rem] mx-auto tw-p-4 tw-flex tw-justify-between tw-items-center"
+    >
+      <div>
+        <p class="tw-text-xs tw-uppercase tw-font-semibold tw-text-pink-300">
+          Impersonation
+        </p>
+        <p class="tw-text-sm">
+          {{ user?.name }}
+        </p>
+        <p class="tw-text-xs">{{ user?.email }}</p>
+      </div>
+      <div>
+        <a
+          href="/impersonate/stop"
+          class="tw-text-xs tw-font-semibold tw-text-pink-300 hover:tw-text-pink-200"
+        >
+          Stop Impersonating
+        </a>
+      </div>
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+import { CurrentUser } from "@/types";
+defineProps<{
+  user?: CurrentUser | null;
+}>();
+</script>
+<style scoped>
+p {
+  margin: 0;
+}
+</style>

--- a/resources/assets/js/components/ImpersonationBanner.vue
+++ b/resources/assets/js/components/ImpersonationBanner.vue
@@ -1,23 +1,20 @@
 <template>
-  <div class="impersonation-banner tw-bg-pink-500 tw-text-pink-100">
+  <div class="impersonation-banner tw-bg-[#c42da8] tw-text-pink-50 tw-sticky tw-top-0 tw-z-10">
     <div
       class="tw-max-w-[90rem] mx-auto tw-p-4 tw-flex tw-justify-between tw-items-center"
     >
       <div>
-        <p class="tw-text-xs tw-uppercase tw-font-semibold tw-text-pink-300">
-          Impersonation
-        </p>
-        <p class="tw-text-sm">
+        <p class="tw-text-sm tw-font-semibold">
           {{ user?.name }}
         </p>
-        <p class="tw-text-xs">{{ user?.email }}</p>
+        <p class="tw-text-xs tw-text-pink-200">{{ user?.email }}</p>
       </div>
       <div>
         <a
           href="/impersonate/stop"
-          class="tw-text-xs tw-font-semibold tw-text-pink-300 hover:tw-text-pink-200"
+          class="tw-border tw-border-pink-50 tw-text-pink-50 tw-px-4 py-2 tw-rounded-md hover:tw-no-underline hover:tw-bg-pink-50 hover:tw-text-pink-800 tw-text-sm sm:tw-text-base"
         >
-          Stop Impersonating
+          Leave Impersonation
         </a>
       </div>
     </div>

--- a/resources/assets/js/layouts/DefaultLayout.vue
+++ b/resources/assets/js/layouts/DefaultLayout.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="default-layout d-flex flex-column">
+    <ImpersonationBanner v-if="user?.isImpersonated" :user="user" />
     <AppHeader>
       <template #app-link>
         <router-link to="/">ChimeIn</router-link>
@@ -27,12 +28,13 @@
 </template>
 <script setup lang="ts">
 import { AppHeader, AppFooter, NavbarItem } from "@umn-latis/cla-vue-template";
+import ImpersonationBanner from "@/components/ImpersonationBanner.vue";
 import { computed } from "vue";
-import type { User } from "../types";
+import type { CurrentUser } from "../types";
 
 const props = withDefaults(
   defineProps<{
-    user?: User | null;
+    user?: CurrentUser | null;
   }>(),
   {
     user: null,

--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -14,6 +14,10 @@ export interface User {
   [key: string]: any;
 }
 
+export interface CurrentUser extends User {
+  isImpersonated: boolean;
+}
+
 export interface SortableUser extends User {
   lastName: string;
   firstName: string;

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,13 +22,6 @@ use App\Http\Controllers\UsersController;
 |
 */
 
-// Home Page Routes
-// 
-// 
-
-// this might be wrong
-Route::impersonate();
-
 Route::get("/ltiSelectionPromptDemo", function() {
     $chime = \App\Chime::first();
     $chimes = \App\Chime::all();

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\ResponseController;
 use App\Http\Controllers\FolderController;
 use App\Http\Controllers\PresentController;
 use App\Http\Controllers\UsersController;
+use App\Http\Controllers\ImpersonateController;
 
 
 /*
@@ -99,7 +100,8 @@ Route::group(['middleware' => ['shibinjection']], function () {
     Route::post('/api/chime/{chime_id}/folder/{folder_id}/question/{question_id}', 'PresentController@startSession');
     Route::put('/api/chime/{chime_id}/folder/{folder_id}/question/{question_id}/stopSession', 'PresentController@stopSession');
     
-    
+    Route::get('/impersonate/stop', [ImpersonateController::class, 'stop'])->name('impersonate.stop');
+
 });
     // Auth::routes();
 


### PR DESCRIPTION
![ScreenShot 2024-11-25 at 14 50 30@2x](https://github.com/user-attachments/assets/a9f32d34-5d91-413a-977a-5b894efadab3)

- Adds an Impersonation banner (similar to Bluesheet) when user is impersonating another user, including the impersonated user's name, email, and a Leave Impersonation button.
- Removes the old impersonation Lab404 package as we're now relying on Nova's impersonation system.
- Adds a route `/impersonate/stop` to stop impersonation.

Also:
- Fixes an issue where the impersonating admin would see their own user name/email rather than the user's on the home page because shib injection middleware overrides any impersonated user info. This PR just skips shib injection when impersonating a user.
