### PR TITLE
check that user can edit chime before syncing users

### DIFF
--- a/app/Http/Controllers/ChimeController.php
+++ b/app/Http/Controllers/ChimeController.php
@@ -178,9 +178,18 @@ class ChimeController extends Controller
 
     public function syncUsers(Chime $chime, Request $req) {
         $user = Auth::user();
-        // check perm
 
-        $users = $req->get('users');
+        if (! $user->canEditChime($chime->id)) {
+            return response()->json(["error" => "You do not have permission to edit this chime"], 403);
+        }
+
+        $validated = $req->validate([
+            'users' => 'required|array',
+            'users.*.id' => 'required|integer|exists:users,id',
+            'users.*.permission_number' => 'required|integer|numeric|multiple_of:100|min:0|max:300'
+        ]);
+
+        $users = $validated['users'];
         $mappedUsers = array_reduce($users, function($result, $u) {
             $result[$u['id']] = ["permission_number" => $u['permission_number']];
             return $result;

--- a/cypress/e2e/api/chimeUser.js
+++ b/cypress/e2e/api/chimeUser.js
@@ -35,6 +35,25 @@ export function updateChimeUser(
   );
 }
 
+export function syncChimeUsers({ chimeId, users }, options) {
+  return cy.csrfToken().then((_token) => {
+    return cy
+      .request({
+        method: "PUT",
+        url: `/api/chime/${chimeId}/users`,
+        body: {
+          _token,
+          users,
+        },
+        ...options,
+      })
+      .then((req) => {
+        if (req.status !== 200) return req;
+        return req.body;
+      });
+  });
+}
+
 export function removeChimeUser({ chimeId, userId }, opts) {
   return cy.csrfToken().then((_token) => {
     cy.request({

--- a/cypress/e2e/api/chimeUsers.test.js
+++ b/cypress/e2e/api/chimeUsers.test.js
@@ -54,7 +54,7 @@ describe("chimeUser api", () => {
       });
   });
 
-  it("does not allow participants/guests to change role", () => {
+  it("does not allow participants/guests to update a single user role", () => {
     let student = null;
 
     cy.logout();
@@ -84,6 +84,53 @@ describe("chimeUser api", () => {
         );
       })
       .then((response) => {
+        expect(response.status).to.equal(403);
+      });
+  });
+
+  it('allows presenters to "sync" users', () => {
+    cy.logout();
+    cy.login("student");
+    cy.visit("/join/" + testChime.access_code);
+    cy.login("faculty");
+
+    api
+      .getChimeUsers({ chimeId: testChime.id })
+      .then((users) => {
+        expect(users).to.have.length(2);
+        // promote a student to presenter
+        return api.syncChimeUsers({
+          chimeId: testChime.id,
+          users: [
+            ...users,
+            {
+              id: users[1].id,
+              permission_number: 300,
+            },
+          ],
+        });
+      })
+      .then(() => {
+        return api.getChimeUsers({ chimeId: testChime.id });
+      })
+      .then((users) => {
+        expect(users).to.have.length(2);
+        expect(users[1].permission_number).to.equal(300);
+      });
+  });
+
+  it('does not allow participants/guests to "sync" users', () => {
+    cy.logout();
+    cy.login("student");
+    cy.visit("/join/" + testChime.access_code);
+
+    api
+      .syncChimeUsers(
+        { chimeId: testChime.id, users: [] },
+        { failOnStatusCode: false }
+      )
+      .then((response) => {
+        console.log({ response });
         expect(response.status).to.equal(403);
       });
   });


### PR DESCRIPTION
- Fixes an issue where a participant user could change a chime members or permissions with sync endpoint
- Validates request data
- adds tests for the sync api endpoint
