### PR TITLE
fix: n+1 query on permission change

### DIFF
--- a/app/Http/Controllers/ChimeController.php
+++ b/app/Http/Controllers/ChimeController.php
@@ -176,30 +176,6 @@ class ChimeController extends Controller
         }
     }
 
-    public function syncUsers(Chime $chime, Request $req) {
-        $user = Auth::user();
-
-        if (! $user->canEditChime($chime->id)) {
-            return response()->json(["error" => "You do not have permission to edit this chime"], 403);
-        }
-
-        $validated = $req->validate([
-            'users' => 'required|array',
-            'users.*.id' => 'required|integer|exists:users,id',
-            'users.*.permission_number' => 'required|integer|numeric|multiple_of:100|min:0|max:300'
-        ]);
-
-        $users = $validated['users'];
-        $mappedUsers = array_reduce($users, function($result, $u) {
-            $result[$u['id']] = ["permission_number" => $u['permission_number']];
-            return $result;
-        });        
-
-        $chime->users()->sync($mappedUsers);
-        $chime->save();
-        return response()->json(["success"=>true]);
-    }
-
     public function updateChimeUser(Request $request, Chime $chime, User $user) 
     {
       abort_unless(Auth::user()->canEditChime($chime->id), 403);

--- a/app/Http/Controllers/ChimeController.php
+++ b/app/Http/Controllers/ChimeController.php
@@ -203,7 +203,8 @@ class ChimeController extends Controller
     public function updateChimeUser(Request $request, Chime $chime, User $user) 
     {
       abort_unless(Auth::user()->canEditChime($chime->id), 403);
-      $request->validate([
+      
+      $validated = $request->validate([
         'permission_number' => [
           'required', 
           'integer', 
@@ -215,7 +216,7 @@ class ChimeController extends Controller
       ]);
 
       $chime->users()->updateExistingPivot($user->id, [
-        'permission_number' => $request->input('permission_number')
+        'permission_number' => $validated['permission_number']
       ]);
 
       return response()->json(["success"=>true]);

--- a/cypress/e2e/api/chimeUser.js
+++ b/cypress/e2e/api/chimeUser.js
@@ -35,25 +35,6 @@ export function updateChimeUser(
   );
 }
 
-export function syncChimeUsers({ chimeId, users }, options) {
-  return cy.csrfToken().then((_token) => {
-    return cy
-      .request({
-        method: "PUT",
-        url: `/api/chime/${chimeId}/users`,
-        body: {
-          _token,
-          users,
-        },
-        ...options,
-      })
-      .then((req) => {
-        if (req.status !== 200) return req;
-        return req.body;
-      });
-  });
-}
-
 export function removeChimeUser({ chimeId, userId }, opts) {
   return cy.csrfToken().then((_token) => {
     cy.request({

--- a/cypress/e2e/api/chimeUsers.test.js
+++ b/cypress/e2e/api/chimeUsers.test.js
@@ -88,53 +88,6 @@ describe("chimeUser api", () => {
       });
   });
 
-  it('allows presenters to "sync" users', () => {
-    cy.logout();
-    cy.login("student");
-    cy.visit("/join/" + testChime.access_code);
-    cy.login("faculty");
-
-    api
-      .getChimeUsers({ chimeId: testChime.id })
-      .then((users) => {
-        expect(users).to.have.length(2);
-        // promote a student to presenter
-        return api.syncChimeUsers({
-          chimeId: testChime.id,
-          users: [
-            ...users,
-            {
-              id: users[1].id,
-              permission_number: 300,
-            },
-          ],
-        });
-      })
-      .then(() => {
-        return api.getChimeUsers({ chimeId: testChime.id });
-      })
-      .then((users) => {
-        expect(users).to.have.length(2);
-        expect(users[1].permission_number).to.equal(300);
-      });
-  });
-
-  it('does not allow participants/guests to "sync" users', () => {
-    cy.logout();
-    cy.login("student");
-    cy.visit("/join/" + testChime.access_code);
-
-    api
-      .syncChimeUsers(
-        { chimeId: testChime.id, users: [] },
-        { failOnStatusCode: false }
-      )
-      .then((response) => {
-        console.log({ response });
-        expect(response.status).to.equal(403);
-      });
-  });
-
   it("lets presenters remove a participant from a chime", () => {
     let student = null;
 

--- a/resources/assets/js/common/api.ts
+++ b/resources/assets/js/common/api.ts
@@ -247,13 +247,28 @@ export function getChimeUsers(chimeId: number): Promise<User[]> {
     });
 }
 
-export function updateChimeUsers(
+export async function updateChimeUserPermissions({
+  chimeId, userId, permissionNumber
+}: {
   chimeId: number,
-  users: User[]
-): Promise<MessageEvent> {
-  return axios.put(`/api/chime/${chimeId}/users`, { users }).then((res) => {
-    return res.data;
+  userId: number,
+  permissionNumber: number
+}) {
+  const res = await axios.put<{ success: boolean}>(`/api/chime/${chimeId}/users/${userId}`, {
+    permission_number: permissionNumber
   });
+  
+  return res.data;
+}
+
+export async function removeChimeUser({
+  chimeId, userId
+}: {
+  chimeId: number,
+  userId: number
+}) {
+  const res = await axios.delete<{ success: boolean}>(`/api/chime/${chimeId}/users/${userId}`);
+  return res.data;
 }
 
 export function getChime(chimeId: number): Promise<Chime> {

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,7 +49,6 @@ Route::group(['middleware' => ['shibinjection']], function () {
     Route::get('/api/chime/{chime_id}', 'ChimeController@getChime');
     Route::get('/api/chime/{chime_id}/users', 'ChimeController@getUsers');
     Route::post('/api/chime/{chime}/sync', 'ChimeController@forceSync');
-    Route::put('/api/chime/{chime}/users', 'ChimeController@syncUsers');
     Route::put('/api/chime/{chime}/users/{user}', [ChimeController::class, 'updateChimeUser']);
     Route::delete('/api/chime/{chime_id}/users/{user_id}', [ChimeController::class, 'removeChimeUser']);
 


### PR DESCRIPTION
Resolves #513: syncUsers can trigger an n+1 query. 

We already have endpoints for updating and removing users from a Chime, so this changes the frontend to use the update/remove endpoints rather than syncing the full member list on each update. Then `syncUsers` is removed since it's not used elsewhere.