### PR TITLE
Add separate shuffle and refresh buttons to wordcloud

### DIFF
--- a/resources/assets/js/views/PresentPage/VWordCloud.vue
+++ b/resources/assets/js/views/PresentPage/VWordCloud.vue
@@ -1,10 +1,24 @@
 <template>
-  <div class="wordcloud" data-cy="word-cloud">
+  <div class="wordcloud tw-rounded-md" data-cy="word-cloud">
     <div class="position-relative wordcloud-wrap">
-      <button class="wordcloud__refresh-btn btn" @click="renderWordcloud">
-        <i class="material-icons">refresh</i>
-        <span class="sr-only">Refresh</span>
-      </button>
+      <div
+        class="tw-flex tw-items-center tw-justify-end tw-relative tw-z-10 tw-p-1 gap-1"
+      >
+        <button
+          class="tw-border-none tw-p-2 tw-bg-black/5 hover:tw-bg-black/10 tw-transition-colors tw-rounded tw-inline-flex tw-items-center tw-justify-center"
+          @click="renderWordcloud"
+        >
+          <i class="material-icons">shuffle</i>
+          <span class="sr-only">Shuffle Wordcloud</span>
+        </button>
+        <button
+          class="tw-border-none tw-p-2 tw-bg-black/5 hover:tw-bg-black/10 tw-transition-colors tw-rounded tw-inline-flex tw-items-center tw-justify-center"
+          @click="handleReloadPage"
+        >
+          <i class="material-icons">refresh</i>
+          <span class="sr-only">Refresh Page</span>
+        </button>
+      </div>
       <div ref="canvasRoot" class="canvas-container"></div>
       <div class="slot-wrap">
         <slot></slot>
@@ -139,6 +153,11 @@ function renderWordcloud() {
   });
 }
 
+function handleReloadPage() {
+  // in case the websocket connection breaks, reload the page
+  window.location.reload();
+}
+
 watchEffect(renderWordcloud);
 onMounted(renderWordcloud);
 </script>
@@ -151,12 +170,6 @@ onMounted(renderWordcloud);
   height: 500px;
   max-height: 70vh;
   position: relative;
-}
-.wordcloud__refresh-btn {
-  position: absolute;
-  top: 0;
-  right: 0;
-  z-index: 1;
 }
 .canvas-container {
   position: absolute;

--- a/resources/assets/js/views/PresentPage/VWordCloud.vue
+++ b/resources/assets/js/views/PresentPage/VWordCloud.vue
@@ -5,14 +5,14 @@
         class="tw-flex tw-items-center tw-justify-end tw-relative tw-z-10 tw-p-1 gap-1"
       >
         <button
-          class="tw-border-none tw-p-2 tw-bg-black/5 hover:tw-bg-black/10 tw-transition-colors tw-rounded tw-inline-flex tw-items-center tw-justify-center"
+          class="tw-border tw-p-2 tw-bg-black/5 hover:tw-bg-black/10 tw-transition-colors tw-rounded tw-inline-flex tw-items-center tw-justify-center tw-backdrop-blur-sm tw-border-neutral-200"
           @click="renderWordcloud"
         >
           <i class="material-icons">shuffle</i>
           <span class="sr-only">Shuffle Wordcloud</span>
         </button>
         <button
-          class="tw-border-none tw-p-2 tw-bg-black/5 hover:tw-bg-black/10 tw-transition-colors tw-rounded tw-inline-flex tw-items-center tw-justify-center"
+          class="tw-p-2 tw-bg-black/5 tw-backdrop-blur-sm hover:tw-bg-black/10 tw-transition-colors tw-rounded tw-inline-flex tw-items-center tw-justify-center tw-border tw-border-neutral-200"
           @click="handleReloadPage"
         >
           <i class="material-icons">refresh</i>


### PR DESCRIPTION
Fixes #594

Sometimes a presenter's websocket connection breaks and their wordcloud no longer receives updates. In a large session, I witnessed the presenter repeatedly click the "refresh" button trying to see the updates, but the refresh button just rerendered the wordcloud and did not reload the whole page.

This changes the wordcloud to have two buttons: "shuffle" which rerender to the cloud,  and "refresh" to reload the page.

![ScreenShot 2024-12-03 at 12 45 05@2x](https://github.com/user-attachments/assets/8578cf8d-96bb-4d91-b175-23e3124dbf07)
