### PR TITLE
fix: imported questions don't have reindexed sort order

### DIFF
--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -99,7 +99,7 @@ class FolderController extends Controller
             $newQuestion = $question->replicate();
             $newQuestion->folder()->associate($folder);
             $newQuestion->current_session_id = null;
-            $newQuestion->order = ++$currentOrderIndex;
+            $newQuestion->order = $currentOrderIndex;
             $newQuestion->save();
         }
 

--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -93,7 +93,7 @@ class FolderController extends Controller
 
         $currentOrderIndex = $folder->questions->max('order') ?? 0;
 
-        foreach ($sourceFolder->questions as $question) {
+        foreach ($sourceFolder->questions->sortBy('order') as $question) {
             $currentOrderIndex += 1;
 
             $newQuestion = $question->replicate();

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -491,6 +491,10 @@ async function do_import() {
     sourceFolderId: selected_folder_id.value,
   });
   refreshFolder();
+
+  // close the folder settings panel so the user has some signal
+  // that the import was successful
+  show_edit_folder.value = false;
 }
 
 function update_folders() {


### PR DESCRIPTION
Fixes #319

- Updates `importQuestions` so the of the imported questions added after the existing questions
- validates the `folder_id`
- checks that the user has permissions for both current chime  and the source folder's chime
- closes the folder settings panel on successful import so that the user has some signifier that the import was completed
