### PR TITLE
fix: sometimes user permissions don't update

### DIFF
--- a/resources/assets/js/views/ChimePage/ChimeManagement.vue
+++ b/resources/assets/js/views/ChimePage/ChimeManagement.vue
@@ -208,7 +208,6 @@ async function updateChimeUserPermissions(
   userId: number,
   permissionNumber: number
 ) {
-  console.log({ userId, permissionNumber });
   try {
     api.updateChimeUserPermissions({
       chimeId: props.chime.id,

--- a/resources/assets/js/views/ChimePage/ChimeManagement.vue
+++ b/resources/assets/js/views/ChimePage/ChimeManagement.vue
@@ -92,7 +92,16 @@
                   <select
                     v-model="user.permission_number"
                     class="form-control form-control-sm"
-                    @change="updateChimeUserPermissions(user.id, user.permission_number)"
+                    @change="
+                      (event) =>
+                        updateChimeUserPermissions(
+                          user.id,
+                          parseInt(
+                            (event.target as HTMLSelectElement).value,
+                            10
+                          )
+                        )
+                    "
                   >
                     <option value="100">Participant</option>
                     <option value="300">Presenter</option>
@@ -195,13 +204,17 @@ async function saveChime(
   }
 }
 
-async function updateChimeUserPermissions(userId: number, permissionNumber: number) {
+async function updateChimeUserPermissions(
+  userId: number,
+  permissionNumber: number
+) {
+  console.log({ userId, permissionNumber });
   try {
     api.updateChimeUserPermissions({
       chimeId: props.chime.id,
       userId,
       permissionNumber,
-    })
+    });
   } catch (err) {
     store.commit("message", "Could not update user permissions.");
   }


### PR DESCRIPTION
when select value changes sometimes the old `user.permission_number` is passed `updateChimeUserPermission` function. This parses the updated value directly from `event.target`.