### PR TITLE
show error on folder page if user is not presenter

### DIFF
--- a/resources/assets/js/common/api.ts
+++ b/resources/assets/js/common/api.ts
@@ -11,23 +11,21 @@ import type {
   ChimeFolderParticipationSummary,
 } from "../types";
 
-export function getFolderWithQuestions({
+export async function getFolderWithQuestions({
   chimeId,
   folderId,
 }: {
   chimeId: number;
   folderId: number;
 }): Promise<FolderWithQuestions> {
-  return axios
-    .get(`/api/chime/${chimeId}/folder/${folderId}?include_questions=true`)
-    .then((res) => {
-      return {
-        ...res.data,
-        // sort the questions within the folder by their order
-        questions: res.data.questions.sort((a, b) => a.order - b.order),
-      };
-    })
-    .catch((err) => console.error(err));
+  const res = await axios.get(
+    `/api/chime/${chimeId}/folder/${folderId}?include_questions=true`
+  );
+  return {
+    ...res.data,
+    // sort the questions within the folder by their order
+    questions: res.data.questions.sort((a, b) => a.order - b.order),
+  };
 }
 
 export function removeResponsesForQuestion({
@@ -72,20 +70,14 @@ export function updateQuestionOrderInFolder(
     .catch((err) => console.error(err));
 }
 
-export function getOpenSessionsWithinChime(
+export async function getOpenSessionsWithinChime(
   chimeId: number
 ): Promise<Session[]> {
   // Note: the api endpoint is `/openQuestions` but apparently
   // this does not get a list of questions (open or otherwise)
   // instead the enpoint returns the chime and openSessions
-  return axios
-    .get("/api/chime/" + chimeId + "/openQuestions")
-    .then((res) => {
-      return res.data.sessions;
-    })
-    .catch((err) =>
-      console.error(`Error loading folder: ${err.message}`, err.response)
-    );
+  const res = await axios.get("/api/chime/" + chimeId + "/openQuestions");
+  return res.data.sessions;
 }
 
 export function getChimes(): Promise<Chime[]> {
@@ -248,26 +240,34 @@ export function getChimeUsers(chimeId: number): Promise<User[]> {
 }
 
 export async function updateChimeUserPermissions({
-  chimeId, userId, permissionNumber
+  chimeId,
+  userId,
+  permissionNumber,
 }: {
-  chimeId: number,
-  userId: number,
-  permissionNumber: number
+  chimeId: number;
+  userId: number;
+  permissionNumber: number;
 }) {
-  const res = await axios.put<{ success: boolean}>(`/api/chime/${chimeId}/users/${userId}`, {
-    permission_number: permissionNumber
-  });
-  
+  const res = await axios.put<{ success: boolean }>(
+    `/api/chime/${chimeId}/users/${userId}`,
+    {
+      permission_number: permissionNumber,
+    }
+  );
+
   return res.data;
 }
 
 export async function removeChimeUser({
-  chimeId, userId
+  chimeId,
+  userId,
 }: {
-  chimeId: number,
-  userId: number
+  chimeId: number;
+  userId: number;
 }) {
-  const res = await axios.delete<{ success: boolean}>(`/api/chime/${chimeId}/users/${userId}`);
+  const res = await axios.delete<{ success: boolean }>(
+    `/api/chime/${chimeId}/users/${userId}`
+  );
   return res.data;
 }
 

--- a/resources/assets/js/views/ChimePage/ChimeManagement.vue
+++ b/resources/assets/js/views/ChimePage/ChimeManagement.vue
@@ -92,7 +92,16 @@
                   <select
                     v-model="user.permission_number"
                     class="form-control form-control-sm"
-                    @change="updateChimeUserPermissions(user.id, user.permission_number)"
+                    @change="
+                      (event) =>
+                        updateChimeUserPermissions(
+                          user.id,
+                          parseInt(
+                            (event.target as HTMLSelectElement).value,
+                            10
+                          )
+                        )
+                    "
                   >
                     <option value="100">Participant</option>
                     <option value="300">Presenter</option>
@@ -195,13 +204,16 @@ async function saveChime(
   }
 }
 
-async function updateChimeUserPermissions(userId: number, permissionNumber: number) {
+async function updateChimeUserPermissions(
+  userId: number,
+  permissionNumber: number
+) {
   try {
     api.updateChimeUserPermissions({
       chimeId: props.chime.id,
       userId,
       permissionNumber,
-    })
+    });
   } catch (err) {
     store.commit("message", "Could not update user permissions.");
   }

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -341,8 +341,16 @@ const {
   folderId: props.folderId,
 });
 
-watch(fetchFolderError, function (newValue) {
-  if (newValue) handleUnauthorizedUser();
+watch(fetchFolderError, function (hasError) {
+  if (hasError) {
+    store.commit(
+      "message",
+      "Cannot view this folder. Make sure you're logged in and have presenter access for this chime."
+    );
+    console.error(
+      `User ${JSON.stringify(props.user)} is not a presenter for this chime.`
+    );
+  }
 });
 
 const otherFolderSessions = computed(() => {
@@ -371,23 +379,8 @@ const isCanvasChime = computed(() =>
 );
 
 onMounted(async () => {
-  if (props.user.guest_user) {
-    handleUnauthorizedUser();
-    return;
-  }
-
   allSessions.value = await getOpenSessionsWithinChime(props.chimeId);
 });
-
-function handleUnauthorizedUser() {
-  store.commit(
-    "message",
-    "Cannot view this folder. Make sure you're logged in and have presenter access for this chime."
-  );
-  console.error(
-    `User ${JSON.stringify(props.user)} is not a presenter for this chime.`
-  );
-}
 
 function reset() {
   if (

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -316,7 +316,7 @@ const QuestionForm = defineAsyncComponent(
 const props = defineProps<{
   folderId: number;
   chimeId: number;
-  user: T.User;
+  user: T.CurrentUser;
 }>();
 const showModal = ref(false);
 const show_edit_folder = ref(false);

--- a/resources/assets/js/views/FolderPage/FolderPage.vue
+++ b/resources/assets/js/views/FolderPage/FolderPage.vue
@@ -335,9 +335,14 @@ const {
   folder,
   questions,
   refresh: refreshFolder,
+  fetchError: fetchFolderError,
 } = useQuestionListener({
   chimeId: props.chimeId,
   folderId: props.folderId,
+});
+
+watch(fetchFolderError, function (newValue) {
+  if (newValue) handleUnauthorizedUser();
 });
 
 const otherFolderSessions = computed(() => {
@@ -366,16 +371,23 @@ const isCanvasChime = computed(() =>
 );
 
 onMounted(async () => {
-  if (isParticipantView.value) {
-    store.commit("message", "Unauthorized: Only presenters may edit chimes.");
-    console.error(
-      `User ${JSON.stringify(props.user)} is not a presenter for this chime.`
-    );
+  if (props.user.guest_user) {
+    handleUnauthorizedUser();
     return;
   }
 
   allSessions.value = await getOpenSessionsWithinChime(props.chimeId);
 });
+
+function handleUnauthorizedUser() {
+  store.commit(
+    "message",
+    "Cannot view this folder. Make sure you're logged in and have presenter access for this chime."
+  );
+  console.error(
+    `User ${JSON.stringify(props.user)} is not a presenter for this chime.`
+  );
+}
 
 function reset() {
   if (


### PR DESCRIPTION
Fixes #653 

![ScreenShot 2024-12-03 at 16 07 53@2x](https://github.com/user-attachments/assets/70274127-d6e6-42f9-9969-1a0a4ed3c7d8)

When a user without Presenter permissions tries to view the folder page, they may see a spinner if they're not a member of the chime.

This shows an error message anytime a `403` is returned from our attempt to fetch folders.

The `useQuestionListener` composable is updated to catch and expose any errors as a ref: `fetchError`. We watch this ref and dispatch an error message when there's an error.