### PR TITLE
fix: responses in quotes don't filter from wordcloud

### DIFF
--- a/resources/assets/js/views/PresentPage/toWordFrequencyLookup.test.ts
+++ b/resources/assets/js/views/PresentPage/toWordFrequencyLookup.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "@jest/globals";
+import toWordFrequencyLookup, {
+  removeQuotedStrings,
+  getQuotedStrings,
+  getSingleWords,
+  getWordsFromText,
+} from "./toWordFrequencyLookup";
+
+describe("toWordFrequencyLookup", () => {
+  it("gives an object with the frequency of each word in the text", () => {
+    const responseTexts = [
+      "rainbow willow",
+      "willow spruce willow",
+      "pine oak maple",
+    ];
+
+    const result = toWordFrequencyLookup(responseTexts);
+
+    expect(result).toEqual({
+      rainbow: 1,
+      willow: 3,
+      spruce: 1,
+      pine: 1,
+      oak: 1,
+      maple: 1,
+    });
+  });
+
+  it("ignores null response texts", () => {
+    const responseTexts = ["rainbow willow", null, "willow spruce willow"];
+
+    const result = toWordFrequencyLookup(responseTexts);
+
+    expect(result).toEqual({
+      rainbow: 1,
+      willow: 3,
+      spruce: 1,
+    });
+  });
+
+  it('removes stopwords like "the" and "and"', () => {
+    const responseTexts = [
+      "the rainbow willow",
+      "willow and spruce or willow",
+      "the pine, the oak, the maple",
+    ];
+
+    const result = toWordFrequencyLookup(responseTexts);
+
+    expect(result).toEqual({
+      rainbow: 1,
+      willow: 3,
+      spruce: 1,
+      pine: 1,
+      oak: 1,
+      maple: 1,
+    });
+  });
+
+  it("removes simple filtered words", () => {
+    const responseTexts = [
+      "rainbow willow",
+      "willow spruce willow",
+      "pine oak maple",
+    ];
+
+    const result = toWordFrequencyLookup(responseTexts, ["willow"]);
+
+    expect(result).toEqual({
+      rainbow: 1,
+      spruce: 1,
+      pine: 1,
+      oak: 1,
+      maple: 1,
+    });
+  });
+
+  it("treats quoted strings as single words", () => {
+    const responseTexts = ["rainbow willow", '"willow spruce" willow'];
+
+    const result = toWordFrequencyLookup(responseTexts);
+
+    expect(result).toEqual({
+      rainbow: 1,
+      willow: 2,
+      "willow spruce": 1,
+    });
+  });
+
+  it("ignores filtered words in quoted strings", () => {
+    const responseTexts = ["rainbow willow", '"willow spruce" willow'];
+
+    const result = toWordFrequencyLookup(responseTexts, ["willow"]);
+
+    expect(result).toEqual({
+      rainbow: 1,
+      "willow spruce": 1,
+    });
+  });
+
+  it("removes empty strings", () => {
+    const responseTexts = ["rainbow willow", "", "spruce willow"];
+
+    const result = toWordFrequencyLookup(responseTexts);
+
+    expect(result).toEqual({
+      rainbow: 1,
+      willow: 2,
+      spruce: 1,
+    });
+  });
+
+  it("filters quoted strings", () => {
+    const responseTexts = [
+      "rainbow willow",
+      '"willow spruce" willow',
+      '"willow spruce"',
+    ];
+
+    const result = toWordFrequencyLookup(responseTexts, ["willow spruce"]);
+
+    expect(result).toEqual({
+      rainbow: 1,
+      willow: 2,
+    });
+  });
+});
+
+describe("removeQuotedStrings", () => {
+  it("removes quoted strings from text", () => {
+    const text = 'rainbow "willow spruce" willow';
+    expect(removeQuotedStrings(text)).toBe("rainbow willow");
+  });
+
+  it("removes multiple quoted strings from text", () => {
+    const text = 'rainbow "willow spruce" willow "pine oak maple"';
+    expect(removeQuotedStrings(text)).toBe("rainbow willow");
+  });
+});
+
+describe("getQuotedStrings", () => {
+  it("returns an array of quoted strings", () => {
+    const text = 'rainbow "willow spruce" willow "pine oak maple" maple';
+
+    expect(getQuotedStrings(text)).toEqual(["willow spruce", "pine oak maple"]);
+  });
+});
+
+describe("getSingleWords", () => {
+  it("returns an array of single words", () => {
+    const text = 'rainbow "willow spruce" willow "pine oak maple" maple';
+
+    expect(getSingleWords(text)).toEqual([
+      "rainbow",
+      "willow",
+      "spruce",
+      "willow",
+      "pine",
+      "oak",
+      "maple",
+      "maple",
+    ]);
+  });
+
+  it("ignores quotes", () => {
+    const text = 'rainbow "willow spruce" willow "pine oak maple" maple';
+
+    expect(getSingleWords(text)).toEqual([
+      "rainbow",
+      "willow",
+      "spruce",
+      "willow",
+      "pine",
+      "oak",
+      "maple",
+      "maple",
+    ]);
+  });
+
+  it("does not split on '&'", () => {
+    expect(getSingleWords("S&P500")).toEqual(["s&p500"]);
+  });
+});
+
+describe("getWordsFromText", () => {
+  it("returns an array of single words and quoted strings", () => {
+    const text = 'rainbow "willow spruce" willow "pine oak maple" maple';
+
+    expect(getWordsFromText(text)).toEqual([
+      "willow spruce",
+      "pine oak maple",
+      "rainbow",
+      "willow",
+      "maple",
+    ]);
+  });
+
+  it("handles extra spaces", () => {
+    const text = "   maple    spruce  willow  ";
+    expect(getWordsFromText(text)).toEqual(["maple", "spruce", "willow"]);
+  });
+
+  it("filters out given words", () => {
+    const text = 'rainbow "willow spruce" willow "pine oak maple" maple';
+
+    expect(getWordsFromText(text, ["willow"])).toEqual([
+      "willow spruce",
+      "pine oak maple",
+      "rainbow",
+      "maple",
+    ]);
+  });
+});

--- a/resources/assets/js/views/PresentPage/toWordFrequencyLookup.ts
+++ b/resources/assets/js/views/PresentPage/toWordFrequencyLookup.ts
@@ -3,8 +3,11 @@ import { WordFrequencyLookup } from "../../types";
 
 const quotedRegex = /"(?<quoted>[^"]*)"/g;
 
-function removeQuotedStrings(text: string) {
-  return text.replace(quotedRegex, "");
+export function removeQuotedStrings(text: string) {
+  return text
+    .replace(quotedRegex, "") // remove quoted strings
+    .replace(/\s+/g, " ") // remove extra whitespace
+    .trim(); // remove leading/trailing whitespace
 }
 
 export function getQuotedStrings(text): string[] {
@@ -12,7 +15,7 @@ export function getQuotedStrings(text): string[] {
   return [...text.matchAll(quotedRegex)].map((m) => m[1]);
 }
 
-function getSingleWords(text) {
+export function getSingleWords(text) {
   return (
     text
       .toLowerCase()
@@ -23,10 +26,13 @@ function getSingleWords(text) {
   );
 }
 
-function getWordsFromText(
+export function getWordsFromText(
   text: string,
   filteredWords: string[] = []
 ): string[] {
+  // remove extra whitespace
+  text = text.replace(/\s+/g, " ").trim();
+
   const textWithoutQuotedStrings = removeQuotedStrings(text);
   const singleWords = getSingleWords(textWithoutQuotedStrings);
 
@@ -46,12 +52,18 @@ export default function toWordFrequencyLookup(
   responseTexts: (string | null)[],
   filteredWords: string[] = []
 ): WordFrequencyLookup {
+  const filteredWordsSet = new Set(filteredWords);
+
   return (
     responseTexts
       // remove null responses
       .filter(isNotEmpty)
       .flatMap((text) => getWordsFromText(text, filteredWords))
       .reduce((acc, word) => {
+        if (word === "" || filteredWordsSet.has(word)) {
+          return acc;
+        }
+
         const prevWordCount = acc[word] || 0;
         return {
           ...acc,

--- a/resources/assets/js/views/PresentPage/toWordFrequencyLookup.ts
+++ b/resources/assets/js/views/PresentPage/toWordFrequencyLookup.ts
@@ -33,15 +33,16 @@ export function getWordsFromText(
   // remove extra whitespace
   text = text.replace(/\s+/g, " ").trim();
 
+  const filteredWordsSet = new Set(filteredWords);
   const textWithoutQuotedStrings = removeQuotedStrings(text);
   const singleWords = getSingleWords(textWithoutQuotedStrings);
 
   // remove stopwords and filtered words
-  const normalizedSingleWords = removeStopwords(singleWords).filter(
-    (word) => !filteredWords.includes(word)
-  );
+  const normalizedSingleWords = removeStopwords(singleWords);
 
-  return [...getQuotedStrings(text), ...normalizedSingleWords];
+  return [...getQuotedStrings(text), ...normalizedSingleWords]
+    .map((word) => word.trim())
+    .filter((word) => word !== "" && !filteredWordsSet.has(word));
 }
 
 function isNotEmpty<TValue>(value: TValue | null | undefined): value is TValue {
@@ -52,18 +53,12 @@ export default function toWordFrequencyLookup(
   responseTexts: (string | null)[],
   filteredWords: string[] = []
 ): WordFrequencyLookup {
-  const filteredWordsSet = new Set(filteredWords);
-
   return (
     responseTexts
       // remove null responses
       .filter(isNotEmpty)
       .flatMap((text) => getWordsFromText(text, filteredWords))
       .reduce((acc, word) => {
-        if (word === "" || filteredWordsSet.has(word)) {
-          return acc;
-        }
-
         const prevWordCount = acc[word] || 0;
         return {
           ...acc,


### PR DESCRIPTION
![ScreenShot 2024-12-04 at 12 03 34](https://github.com/user-attachments/assets/6ad847a8-9de7-401d-a13a-683158fed36c)

- fixes filtering so that it applies to quoted text as well
- adds tests

Fixes #655