### PR TITLE
fix(test): only warn on unused variables

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,6 +28,7 @@ module.exports = {
     "vue/attribute-hyphenation": ["error", "never"],
     "vue/v-on-event-hyphenation": ["error", "never"],
     "vue/component-definition-name-casing": "off",
+    "vue/no-unused-vars": "warn",
     "vue/component-name-in-template-casing": [
       "warn",
       "PascalCase",

--- a/resources/assets/js/views/ChimePage/ChimeManagement.vue
+++ b/resources/assets/js/views/ChimePage/ChimeManagement.vue
@@ -85,7 +85,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(user, index) in sortedUsers" :key="user.id">
+              <tr v-for="user in sortedUsers" :key="user.id">
                 <td>{{ user.name }}</td>
                 <td>{{ user.email }}</td>
                 <td data-cy="select-user-permissions-in-chime">


### PR DESCRIPTION
Fixes ChimeIn tests failing at eslint check. 

- changes eslint from "error" (default) to "warn" when there's an unused variable in a vue file.
- removes the unused `index` variable regardless

