### PR TITLE
fix: unordered lists with using quill will show as ordered

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -245,6 +245,10 @@ ul {
   min-height: 100%;
 }
 
-li[data-list="bullet"] {
+// This is a fix for unordered lists appearing as ordered lists
+// in the quill editor. Quill v2 always uses ordered lists.
+// when rendering, make sure the bullet style is disc,
+// but let the quill editor handle it's own bullet style
+li[data-list="bullet"]:not(.ql-editor li[data-list="bullet"]) {
   list-style-type: disc;
 }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -244,3 +244,7 @@ ul {
 .min-h-full {
   min-height: 100%;
 }
+
+li[data-list="bullet"] {
+  list-style-type: disc;
+}


### PR DESCRIPTION
Quill2 always uses `<ol>` ([by design](https://github.com/slab/quill/issues/3957)) for both ordered and unordered lists. This is causing all lists in ChimeIn to be rendered as ordered list.

The proper fix is to use Quill's `getSemanticHTML` when saving updates – currently we're saving Quill's markup.

But, for now, this CSS should be a valid workaround. The `:not(.ql-editor ...)` is there to avoid rendering double-bullets within the editor, because Quill handles in-editor rendering just fine.

On dev for testing.


https://github.com/user-attachments/assets/29b043b3-eaf5-42b1-ad43-46daad280e85

