### PR TITLE
Show spinner on Force Sync button when sync is in progress

### DIFF
--- a/resources/assets/js/components/ForceSyncButton.vue
+++ b/resources/assets/js/components/ForceSyncButton.vue
@@ -1,0 +1,73 @@
+<template>
+  <button class="btn btn-outline-success btn-sm align-items-center d-flex">
+    <slot />
+    <span
+      class="sync-status md-18 material-icons"
+      :class="{
+        'sync-status--is-success': props.forceSyncState === 'success',
+        'sync-status--is-inprogress': props.forceSyncState === 'inProgress',
+        'sync-status--is-error': props.forceSyncState === 'error',
+        'sync-status--is-idle': props.forceSyncState === 'idle',
+      }"
+    >
+      {{ currentStatusIcon.icon }}
+    </span>
+    <span class="sr-only">{{ currentStatusIcon.alt }}</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { AsyncActionState } from "@/types";
+
+const props = defineProps<{
+  forceSyncState: AsyncActionState;
+}>();
+
+const statuses: Record<AsyncActionState, { icon: string; alt: string }> = {
+  success: {
+    icon: "check_circle",
+    alt: "Success",
+  },
+  inProgress: {
+    icon: "sync",
+    alt: "Sync In Progress... please wait",
+  },
+  error: {
+    icon: "error",
+    alt: "Error",
+  },
+  idle: {
+    icon: "sync",
+    alt: "Start Sync",
+  },
+};
+
+const currentStatusIcon = computed(() => statuses[props.forceSyncState]);
+</script>
+
+<style scoped>
+.sync-status {
+  display: flex;
+  align-items: center;
+}
+
+.sync-status--is-inprogress {
+  animation: 1s infinite spin;
+}
+
+.sync-status--is-error {
+  margin: 0.5rem 0;
+  color: #dc3545;
+  font-size: 0.9rem;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(360deg);
+  }
+  to {
+    transform: rotate(0deg);
+  }
+}
+</style>

--- a/resources/assets/js/components/ForceSyncButton.vue
+++ b/resources/assets/js/components/ForceSyncButton.vue
@@ -1,5 +1,12 @@
 <template>
-  <button class="btn btn-outline-success btn-sm align-items-center d-flex">
+  <button
+    class="btn btn-sm tw-flex tw-items-center tw-justify-center gap-1"
+    type="button"
+    :class="{
+      'btn-outline-secondary': props.forceSyncState === 'error',
+      'btn-success': props.forceSyncState !== 'error',
+    }"
+  >
     <slot />
     <span
       class="sync-status md-18 material-icons"

--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -138,7 +138,7 @@ export interface Question<T extends QuestionInfo = QuestionInfo> {
   text: HTMLString;
   folder_id: number;
   order: number; // could be non-consecutive, like (3, 5, 6, 10)
-  index: number; // 0-based consecutive order (0, 1, 2, 3) 
+  index: number; // 0-based consecutive order (0, 1, 2, 3)
   question_info: T;
   anonymous: boolean;
   allow_multiple: boolean;
@@ -326,3 +326,5 @@ export interface ChimeFolderParticipationSummary {
 export type PartialNested<T> = {
   [P in keyof T]?: PartialNested<T[P]>;
 };
+
+export type AsyncActionState = "idle" | "inProgress" | "success" | "error";

--- a/resources/assets/js/views/ChimePage/ChimeManagement.vue
+++ b/resources/assets/js/views/ChimePage/ChimeManagement.vue
@@ -44,23 +44,14 @@
             "
             @update="handleUpdateChimeOptions"
           />
-          <button
+          <ForceSyncButton
             v-if="isCanvasChime && chime.lti_grade_mode === 'one_grade'"
-            class="btn btn-outline-success btn-sm align-items-center d-flex"
+            :forceSyncState="forceSyncState"
+            class="!btn-outline-success"
             @click="forceSyncGrades"
           >
             Force Sync with Canvas
-            <span
-              v-if="forceSyncState === 'success'"
-              class="material-icons sync-status sync-status--is-success md-18"
-              >check_circle</span
-            >
-            <span
-              v-if="forceSyncState === 'inProgress'"
-              class="material-icons sync-status sync-status--is-inprogress md-18"
-              >sync</span
-            >
-          </button>
+          </ForceSyncButton>
           <div
             v-if="forceSyncState === 'error'"
             class="sync-status sync-status--is-error"
@@ -133,6 +124,7 @@ import JoinPanel from "../../components/JoinPanel.vue";
 import { useStore } from "vuex";
 import { selectIsCanvasChime } from "../../helpers/chimeSelectors";
 import type { Chime, ChimeOptions, User, Partial } from "../../types";
+import ForceSyncButton from "@/components/ForceSyncButton.vue";
 
 const props = defineProps<{
   chime: Chime;


### PR DESCRIPTION
Resolves #947 

In one-grade mode, ChimeIn will show a spinner on the "Force Sync Chime" button while syncing (in Chime settings). In multiple-grade mode, the Force Sync button (in Folder settings) is missing the same sync-feedback, which is confusing to the user.

This extracts the Force Sync button from Chime settings and uses it in Folder settings. This new `<ForceSyncButton>` is a dumb component, meaning logic for sync state actions are kept in the original components.


https://github.com/user-attachments/assets/014af2c1-9ef5-4164-ba15-f2ad7be47064

