### PR TITLE
handle missing x-axis labels in numeric questions

### DIFF
--- a/resources/assets/js/components/NumericResponse/BarChartResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/BarChartResponseInputs.vue
@@ -1,7 +1,7 @@
 <template>
   <NumInput
     :id="`numeric-x-input`"
-    :label="questionOptions.x_axis_label || 'X'"
+    :label="questionOptions.x_axis_label"
     :modelValue="responseInfo.x ?? 0"
     @update:modelValue="
       $emit('update:responseInfo', { ...responseInfo, x: $event })

--- a/resources/assets/js/components/NumericResponse/BarChartResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/BarChartResponseInputs.vue
@@ -1,7 +1,7 @@
 <template>
   <NumInput
     :id="`numeric-x-input`"
-    :label="questionOptions.x_axis_label"
+    :label="questionOptions.x_axis_label ?? 'X'"
     :modelValue="responseInfo.x ?? 0"
     @update:modelValue="
       $emit('update:responseInfo', { ...responseInfo, x: $event })

--- a/resources/assets/js/components/NumericResponse/BarChartResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/BarChartResponseInputs.vue
@@ -1,7 +1,7 @@
 <template>
   <NumInput
     :id="`numeric-x-input`"
-    :label="questionOptions.x_axis_label ?? 'X'"
+    :label="questionOptions.x_axis_label || 'X'"
     :modelValue="responseInfo.x ?? 0"
     @update:modelValue="
       $emit('update:responseInfo', { ...responseInfo, x: $event })
@@ -12,11 +12,11 @@
 import NumInput from "@/components/NumberInputGroup.vue";
 import {
   NumericResponseResponseInfo,
-  NumericResponseQuestionInfo,
+  NormalizedNumericQuestionOptions,
 } from "@/types";
 
 defineProps<{
-  questionOptions: NumericResponseQuestionInfo["question_responses"];
+  questionOptions: NormalizedNumericQuestionOptions;
   disabled: boolean;
   responseInfo: NumericResponseResponseInfo;
 }>();

--- a/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/NumericResponseInputs.vue
@@ -62,6 +62,7 @@
 </template>
 <script setup lang="ts">
 import {
+  NormalizedNumericQuestionOptions,
   NumericResponseQuestionInfo,
   NumericResponseResponseInfo,
   Question,
@@ -72,6 +73,7 @@ import { computed, reactive, ref, watch } from "vue";
 import BarChartResponseInputs from "./BarChartResponseInputs.vue";
 import ScatterPlotResponseInputs from "./ScatterPlotResponseInputs.vue";
 import RangeChartResponseInputs from "./RangeChartResponseInputs.vue";
+import { normalizeNumericQuestionOptions } from "@/helpers/getNormedNumericQuestionOptions";
 
 const props = defineProps<{
   question: Question<NumericResponseQuestionInfo>;
@@ -125,8 +127,10 @@ watch(
   { immediate: true }
 );
 
-const questionOptions = computed(() => {
-  return props.question.question_info.question_responses;
+const questionOptions = computed((): NormalizedNumericQuestionOptions => {
+  return normalizeNumericQuestionOptions(
+    props.question.question_info.question_responses
+  );
 });
 
 function handleSave() {

--- a/resources/assets/js/components/NumericResponse/RangeChartResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/RangeChartResponseInputs.vue
@@ -25,12 +25,12 @@
 import NumInput from "@/components/NumberInputGroup.vue";
 import {
   NumericResponseResponseInfo,
-  NumericResponseQuestionInfo,
+  NormalizedNumericQuestionOptions,
 } from "@/types";
 import { computed } from "vue";
 
 const props = defineProps<{
-  questionOptions: NumericResponseQuestionInfo["question_responses"];
+  questionOptions: NormalizedNumericQuestionOptions;
   disabled: boolean;
   responseInfo: Pick<NumericResponseResponseInfo, "question_type" | "xRange">;
 }>();

--- a/resources/assets/js/components/NumericResponse/ScatterPlotResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/ScatterPlotResponseInputs.vue
@@ -2,7 +2,7 @@
   <div class="d-flex gap-3">
     <NumInput
       id="numeric-x-input"
-      :label="questionOptions.x_axis_label || 'X'"
+      :label="questionOptions.x_axis_label"
       :modelValue="responseInfo.x ?? 0"
       :disabled="disabled"
       @update:modelValue="
@@ -11,7 +11,7 @@
     />
     <NumInput
       id="numeric-y-input"
-      :label="questionOptions.y_axis_label || 'Y'"
+      :label="questionOptions.y_axis_label"
       :modelValue="responseInfo.y ?? 0"
       :disabled="disabled"
       @update:modelValue="

--- a/resources/assets/js/components/NumericResponse/ScatterPlotResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/ScatterPlotResponseInputs.vue
@@ -2,7 +2,7 @@
   <div class="d-flex gap-3">
     <NumInput
       id="numeric-x-input"
-      :label="questionOptions.x_axis_label"
+      :label="questionOptions.x_axis_label ?? 'X'"
       :modelValue="responseInfo.x ?? 0"
       :disabled="disabled"
       @update:modelValue="

--- a/resources/assets/js/components/NumericResponse/ScatterPlotResponseInputs.vue
+++ b/resources/assets/js/components/NumericResponse/ScatterPlotResponseInputs.vue
@@ -2,7 +2,7 @@
   <div class="d-flex gap-3">
     <NumInput
       id="numeric-x-input"
-      :label="questionOptions.x_axis_label ?? 'X'"
+      :label="questionOptions.x_axis_label || 'X'"
       :modelValue="responseInfo.x ?? 0"
       :disabled="disabled"
       @update:modelValue="
@@ -11,7 +11,7 @@
     />
     <NumInput
       id="numeric-y-input"
-      :label="questionOptions.y_axis_label ?? 'Y'"
+      :label="questionOptions.y_axis_label || 'Y'"
       :modelValue="responseInfo.y ?? 0"
       :disabled="disabled"
       @update:modelValue="
@@ -24,11 +24,11 @@
 import NumInput from "@/components/NumberInputGroup.vue";
 import {
   NumericResponseResponseInfo,
-  NumericResponseQuestionInfo,
+  NormalizedNumericQuestionOptions,
 } from "@/types";
 
 defineProps<{
-  questionOptions: NumericResponseQuestionInfo["question_responses"];
+  questionOptions: NormalizedNumericQuestionOptions;
   disabled: boolean;
   responseInfo: NumericResponseResponseInfo;
 }>();

--- a/resources/assets/js/helpers/getNormedNumericQuestionOptions.ts
+++ b/resources/assets/js/helpers/getNormedNumericQuestionOptions.ts
@@ -1,0 +1,34 @@
+import {
+  NormalizedNumericQuestionOptions,
+  NumericResponseQuestionInfo,
+} from "@/types";
+
+export function isNumericResponseQuestionOptions(
+  question_responses:
+    | NumericResponseQuestionInfo["question_responses"]
+    | unknown
+): question_responses is NormalizedNumericQuestionOptions {
+  return (
+    typeof question_responses === "object" &&
+    question_responses !== null &&
+    "chart_type" in question_responses &&
+    "x_axis_label" in question_responses &&
+    "y_axis_label" in question_responses
+  );
+}
+
+export function getDefaultNumericQuestionOptions(): NormalizedNumericQuestionOptions {
+  return {
+    chart_type: "bar",
+    x_axis_label: "X",
+    y_axis_label: "Y",
+  };
+}
+
+export function normalizeNumericQuestionOptions(
+  question_responses: NumericResponseQuestionInfo["question_responses"]
+): NormalizedNumericQuestionOptions {
+  return isNumericResponseQuestionOptions(question_responses)
+    ? question_responses
+    : getDefaultNumericQuestionOptions();
+}

--- a/resources/assets/js/helpers/getNormedNumericQuestionOptions.ts
+++ b/resources/assets/js/helpers/getNormedNumericQuestionOptions.ts
@@ -17,18 +17,30 @@ export function isNumericResponseQuestionOptions(
   );
 }
 
-export function getDefaultNumericQuestionOptions(): NormalizedNumericQuestionOptions {
-  return {
+/**
+ * Normalizes options for numeric questions returned from the server
+ * so that they're in the correct shape and have truthy values for the labels.
+ * @see Issue#948 for more context
+ */
+export function normalizeNumericQuestionOptions(
+  options: NumericResponseQuestionInfo["question_responses"]
+): NormalizedNumericQuestionOptions {
+  const defaultOptions: NormalizedNumericQuestionOptions = {
     chart_type: "bar",
     x_axis_label: "X",
     y_axis_label: "Y",
   };
-}
 
-export function normalizeNumericQuestionOptions(
-  question_responses: NumericResponseQuestionInfo["question_responses"]
-): NormalizedNumericQuestionOptions {
-  return isNumericResponseQuestionOptions(question_responses)
-    ? question_responses
-    : getDefaultNumericQuestionOptions();
+  // options might be `[]` if no chart type or label was set
+  if (!isNumericResponseQuestionOptions(options)) {
+    return defaultOptions;
+  }
+
+  // label could be an empty string or null. If so, set it to the default.
+  for (const key in options) {
+    if (!options[key]) {
+      options[key] = defaultOptions[key];
+    }
+  }
+  return options;
 }

--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -215,13 +215,17 @@ export interface PinOnImageQuestionInfo extends QuestionInfo {
 
 export type NumericChartType = "bar" | "scatter" | "range";
 
+export interface NormalizedNumericQuestionOptions {
+  chart_type: NumericChartType;
+  x_axis_label: string;
+  y_axis_label: string;
+}
+
+export type RawNumericQuestionOptions = NormalizedNumericQuestionOptions | []; // `[]` may happen if no chart type or label was set;
+
 export interface NumericResponseQuestionInfo extends QuestionInfo {
   question_type: "numeric_response";
-  question_responses: {
-    chart_type: NumericChartType;
-    x_axis_label?: string;
-    y_axis_label?: string; // only for scatter
-  };
+  question_responses: RawNumericQuestionOptions;
 }
 
 export type MultipleChoiceQuestion = Question<MultipleChoiceQuestionInfo>;

--- a/resources/assets/js/types.ts
+++ b/resources/assets/js/types.ts
@@ -219,7 +219,7 @@ export interface NumericResponseQuestionInfo extends QuestionInfo {
   question_type: "numeric_response";
   question_responses: {
     chart_type: NumericChartType;
-    x_axis_label: string;
+    x_axis_label?: string;
     y_axis_label?: string; // only for scatter
   };
 }

--- a/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
@@ -4,18 +4,18 @@
       v-if="chartType === 'bar'"
       :data="barChartData"
       :itemLabel="question.anonymous ? 'Response ID' : 'User'"
-      :xAxisLabel="questionOptions.x_axis_label || 'X'"
+      :xAxisLabel="questionOptions.x_axis_label"
     />
     <ScatterPlot
       v-else-if="chartType === 'scatter'"
       :data="scatterPlotData"
-      :xAxisLabel="questionOptions.x_axis_label || 'X'"
-      :yAxisLabel="questionOptions.y_axis_label || 'Y'"
+      :xAxisLabel="questionOptions.x_axis_label"
+      :yAxisLabel="questionOptions.y_axis_label"
     />
     <RangeChart
       v-else-if="chartType === 'range'"
       :data="rangeChartData"
-      :xAxisLabel="questionOptions.x_axis_label || 'X'"
+      :xAxisLabel="questionOptions.x_axis_label"
     />
   </div>
 </template>

--- a/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
@@ -4,7 +4,7 @@
       v-if="chartType === 'bar'"
       :data="barChartData"
       :itemLabel="question.anonymous ? 'Response ID' : 'User'"
-      :xAxisLabel="questionOptions.x_axis_label"
+      :xAxisLabel="questionOptions.x_axis_label || 'X'"
     />
     <ScatterPlot
       v-else-if="chartType === 'scatter'"
@@ -15,7 +15,7 @@
     <RangeChart
       v-else-if="chartType === 'range'"
       :data="rangeChartData"
-      :xAxisLabel="questionOptions.x_axis_label"
+      :xAxisLabel="questionOptions.x_axis_label || 'X'"
     />
   </div>
 </template>

--- a/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
+++ b/resources/assets/js/views/PresentPage/NumericResponseStatistics.vue
@@ -28,21 +28,23 @@ import type {
   NumericResponseQuestionInfo,
   Question,
   Response,
+  NormalizedNumericQuestionOptions,
 } from "@/types";
 import { computed } from "vue";
+import { normalizeNumericQuestionOptions } from "@/helpers/getNormedNumericQuestionOptions";
 
 const props = defineProps<{
   responses: Response<NumericResponseResponseInfo>[];
   question: Question<NumericResponseQuestionInfo>;
 }>();
 
-const chartType = computed(
-  () => props.question.question_info.question_responses.chart_type
-);
-
-const questionOptions = computed(() => {
-  return props.question.question_info.question_responses;
+const questionOptions = computed((): NormalizedNumericQuestionOptions => {
+  return normalizeNumericQuestionOptions(
+    props.question.question_info.question_responses
+  );
 });
+
+const chartType = computed(() => questionOptions.value.chart_type);
 
 const barChartData = computed((): [label: string, value: number][] => {
   return props.responses.map((response, index) => {

--- a/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
+++ b/resources/assets/js/views/QuestionForm/NumericResponseQuestionOptions.vue
@@ -9,10 +9,10 @@
           class="sr-only"
           name="chart-type"
           value="bar"
-          :checked="typedQuestionResponsesProp.chart_type === 'bar'"
+          :checked="normedQuestionOptions.chart_type === 'bar'"
           @change="
             $emit('update:question_responses', {
-              ...typedQuestionResponsesProp,
+              ...normedQuestionOptions,
               chart_type: 'bar',
             })
           "
@@ -28,10 +28,10 @@
           name="chart-type"
           value="scatter"
           class="sr-only"
-          :checked="typedQuestionResponsesProp.chart_type === 'scatter'"
+          :checked="normedQuestionOptions.chart_type === 'scatter'"
           @change="
             $emit('update:question_responses', {
-              ...typedQuestionResponsesProp,
+              ...normedQuestionOptions,
               chart_type: 'scatter',
             })
           "
@@ -47,10 +47,10 @@
           name="chart-type"
           value="range"
           class="sr-only"
-          :checked="typedQuestionResponsesProp.chart_type === 'range'"
+          :checked="normedQuestionOptions.chart_type === 'range'"
           @change="
             $emit('update:question_responses', {
-              ...typedQuestionResponsesProp,
+              ...normedQuestionOptions,
               chart_type: 'range',
             })
           "
@@ -68,12 +68,12 @@
         <input
           type="text"
           class="form-control"
-          :value="typedQuestionResponsesProp.x_axis_label"
+          :value="normedQuestionOptions.x_axis_label"
           required
           @input="
             (event) =>
               $emit('update:question_responses', {
-                ...typedQuestionResponsesProp,
+                ...normedQuestionOptions,
                 x_axis_label: (event.target as HTMLInputElement).value,
               })
           "
@@ -81,7 +81,7 @@
       </div>
     </div>
 
-    <div v-if="typedQuestionResponsesProp.chart_type === 'scatter'" class="row">
+    <div v-if="normedQuestionOptions.chart_type === 'scatter'" class="row">
       <label for="x-axis-label" class="col-form-label col-sm-3">
         Y Axis Label
       </label>
@@ -89,12 +89,12 @@
         <input
           type="text"
           class="form-control"
-          :value="typedQuestionResponsesProp.y_axis_label"
-          :required="typedQuestionResponsesProp.chart_type === 'scatter'"
+          :value="normedQuestionOptions.y_axis_label"
+          :required="normedQuestionOptions.chart_type === 'scatter'"
           @input="
             (event) =>
               $emit('update:question_responses', {
-                ...typedQuestionResponsesProp,
+                ...normedQuestionOptions,
                 y_axis_label: (event.target as HTMLInputElement).value,
               })
           "
@@ -108,7 +108,8 @@ import IconChartBar from "@/icons/IconChartBar.vue";
 import IconChartScatter from "@/icons/IconChartScatter.vue";
 import IconChartRange from "@/icons/IconChartRange.vue";
 import { NumericResponseQuestionInfo } from "@/types";
-import { computed } from "vue";
+import { normalizeNumericQuestionOptions } from "@/helpers/getNormedNumericQuestionOptions";
+import { computed, onMounted } from "vue";
 
 const props = defineProps<{
   /**
@@ -120,41 +121,24 @@ const props = defineProps<{
    * is an object with the properties we expect.
    */
   // eslint-disable-next-line vue/prop-name-casing
-  question_responses:
-    | NumericResponseQuestionInfo["question_responses"]
-    | unknown;
+  question_responses: NumericResponseQuestionInfo["question_responses"];
 }>();
 
-defineEmits<{
+const emit = defineEmits<{
   (
     event: "update:question_responses",
     value: NumericResponseQuestionInfo["question_responses"]
   ): void;
 }>();
 
-function isNumericResponseQuestionInfo(
-  question_responses:
-    | NumericResponseQuestionInfo["question_responses"]
-    | unknown
-): question_responses is NumericResponseQuestionInfo["question_responses"] {
-  return (
-    typeof question_responses === "object" &&
-    question_responses !== null &&
-    "chart_type" in question_responses &&
-    "x_axis_label" in question_responses &&
-    "y_axis_label" in question_responses
-  );
-}
+const normedQuestionOptions = computed(() =>
+  normalizeNumericQuestionOptions(props.question_responses)
+);
 
-const typedQuestionResponsesProp = computed(() => {
-  if (isNumericResponseQuestionInfo(props.question_responses)) {
-    return props.question_responses;
-  }
-  return {
-    chart_type: "bar",
-    x_axis_label: "",
-    y_axis_label: "",
-  } as NumericResponseQuestionInfo["question_responses"];
+onMounted(() => {
+  // initialize the question options in case they're set to `[]`
+  // or some other value that doesn't match the expected type
+  emit("update:question_responses", normedQuestionOptions.value);
 });
 </script>
 <style scoped>


### PR DESCRIPTION
resolves #948 

- `x_axis_label` is now correctly typed as optional, so that we correctly get red squiggles in code when it's missing.
- Fall back to `X` as an label in statistics and input.

On dev for testing
