### PR TITLE
fix: question move to end after editing

### DIFF
--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -116,7 +116,7 @@ class FolderController extends Controller
             ->first());
         
         if ($chime != null && $chime->pivot->permission_number >= 300) {
-            $currentFolderId = $req->route('folder_id');
+            $currentFolderId = (int) $req->route('folder_id');
             $destFolderId = $req->get('folder_id');
             $currentFolder = $chime->folders()->find($currentFolderId);
             $question = $currentFolder->questions()->find($req->route('question_id'));


### PR DESCRIPTION
Resolves #952 

This regression was introduced in #945, where we moved a question to the end of a folder when current folder id isn't the destination folder id.

To determine if we need to move the question, we compare the current folder id and the destination folder id. However, we have a type mismatch because we're getting the current folder id from the route:
```
// $currentFolderId is a string
$currentFolderId = $req->route('folder_id');

// $destFolderId is an int
$destFolderId = $req->get('folder_id');
```

The solution is to cast `$currentFolderId` as an `int`.