### PR TITLE
refactor `QuestionController::destroy` (stacked on #957)

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -87,7 +87,7 @@ Route::group(['middleware' => ['shibinjection']], function () {
     Route::put('/api/chime/{chime}/folder/{folder}/question/{question}', [QuestionController::class, 'update'])
         ->middleware('limit.json.size');
     Route::put('/api/chime/{chime_id}/folder/{folder_id}/save_order', 'FolderController@saveOrder');
-    Route::delete('/api/chime/{chime_id}/folder/{folder_id}/question/{question_id}', [QuestionController::class, 'destroy']);
+    Route::delete('/api/chime/{chime}/folder/{folder}/question/{question}', [QuestionController::class, 'destroy']);
     Route::delete('/api/chime/{chime}/folder/{folder}/question/{question}/responses', [QuestionController::class, 'reset'] );
     
     Route::delete('/api/chime/{chime}/folder/{folder}/response/{response}', 'ResponseController@deleteResponse');


### PR DESCRIPTION
Stacked on #957 

Refactor `destroy` similar to `update` and `store` methods: let Route-Model binding do some work for us.

No functionality change.