### PR TITLE
periodically resync chime user count

### DIFF
--- a/app/Http/Controllers/ChimeChannelController.php
+++ b/app/Http/Controllers/ChimeChannelController.php
@@ -21,6 +21,16 @@ class ChimeChannelController extends Controller
 
         $redisEntry = "presence-{$channelName}.{$chime->id}:members";
         $membersJson = Redis::get($redisEntry);
+
+        if (!$membersJson) {
+            return response()->json([
+                'chime_id' => $chime->id,
+                'channel_name' => $channelName,
+                'user_ids' => [],
+                'user_count' => 0,
+            ]);
+        }
+
         $members = json_decode($membersJson, true);
 
         $uniqUserIds = collect($members)
@@ -31,6 +41,8 @@ class ChimeChannelController extends Controller
             ->toArray();
 
         return response()->json([
+            'chime_id' => $chime->id,
+            'channel_name' => $channelName,
             'user_ids' => $uniqUserIds,
             'user_count' => count($uniqUserIds),
         ]);

--- a/app/Http/Controllers/ChimeChannelController.php
+++ b/app/Http/Controllers/ChimeChannelController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Chime;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redis;
+
+class ChimeChannelController extends Controller
+{
+    public function show(Request $request, Chime $chime, $channelName)
+    {
+        abort_unless(Auth::user()->canEditChime($chime->id), 403);
+
+        $validChannelNames = [
+            'session-status',
+        ];
+
+        abort_unless(in_array($channelName, $validChannelNames), 404);
+
+        $redisEntry = "presence-{$channelName}.{$chime->id}:members";
+        $membersJson = Redis::get($redisEntry);
+        $members = json_decode($membersJson, true);
+
+        $uniqUserIds = collect($members)
+            ->unique(function ($member) {
+                return $member['user_id'];
+            })
+            ->pluck('user_id')
+            ->toArray();
+
+        return response()->json([
+            'user_ids' => $uniqUserIds,
+            'user_count' => count($uniqUserIds),
+        ]);
+    }
+}

--- a/resources/assets/js/common/api.ts
+++ b/resources/assets/js/common/api.ts
@@ -308,3 +308,15 @@ export function getChimeFolderParticipation({
     )
     .then((res) => res.data);
 }
+
+export async function getChimeChannel(chimeId: number, channelName: string): Promise<{
+  chime_id: number;
+  channel_name: string;
+  user_ids: number[];
+  user_count: number;
+}> {
+  const res = await axios
+    .get(`/api/chime/${chimeId}/channels/${channelName}`);
+
+  return res.data;
+}

--- a/resources/assets/js/hooks/useQuestionListener.ts
+++ b/resources/assets/js/hooks/useQuestionListener.ts
@@ -45,15 +45,20 @@ export default function useQuestionListener({ chimeId, folderId }) {
 
   let resyncUserCountTimeoutId = null as ReturnType<typeof setTimeout> | null;
   async function resyncSessionUserCount(interval = 10 * 60 * 1000) {
-      resyncUserCountTimeoutId = setTimeout(async () => {
-        const {
-          user_count
-        } = await getChimeChannel(chimeId, "session-status");
+    // Clear any existing timeout to prevent multiple timers
+    if (resyncUserCountTimeoutId) {
+      clearTimeout(resyncUserCountTimeoutId);
+    }
 
-        usersCount.value = user_count;
+    resyncUserCountTimeoutId = setTimeout(async () => {
+      const {
+        user_count
+      } = await getChimeChannel(chimeId, "session-status");
 
-        resyncSessionUserCount(interval);
-      }, interval);
+      usersCount.value = user_count;
+
+      resyncSessionUserCount(interval);
+    }, interval);
   }
 
   onMounted(async () => {

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ChimeChannelController;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use App\Http\Controllers\HomeController;
@@ -98,6 +99,7 @@ Route::group(['middleware' => ['shibinjection']], function () {
 
     Route::post('/api/chime/{chime_id}/folder/{folder_id}/question/{question_id}', 'PresentController@startSession');
     Route::put('/api/chime/{chime_id}/folder/{folder_id}/question/{question_id}/stopSession', 'PresentController@stopSession');
+    Route::get('/api/chime/{chime}/channels/{channelName}', [ChimeChannelController::class, 'show']);
     
     Route::get('/impersonate/stop', [ImpersonateController::class, 'stop'])->name('impersonate.stop');
 


### PR DESCRIPTION
Closes #133 

- adds api endpoint for getting current user count
- the frontend will poll the endpoint every 10 min and update its user count. 

Maybe the interval should be longer?

Also considered getting all open channels and broadcasting, but this seemed simpler.
