### PR TITLE
Fix "Attach user" in Nova

### DIFF
--- a/app/Nova/Chime.php
+++ b/app/Nova/Chime.php
@@ -82,14 +82,16 @@ class Chime extends Resource
 
             HasMany::make('Folders'),
 
-            BelongsToMany::make('Users')->fields(function () {
-                return [
-                    Select::make('Role', 'permission_number')->options([
-                        100 => 'Participant',
-                        300 => 'Presenter',
-                    ])->displayUsingLabels()->sortable()->filterable(),
-                ];
-            }),
+            BelongsToMany::make('Users')
+                ->searchable()
+                ->fields(function () {
+                    return [
+                        Select::make('Role', 'permission_number')->options([
+                            100 => 'Participant',
+                            300 => 'Presenter',
+                        ])->displayUsingLabels()->sortable()->filterable(),
+                    ];
+                }),
             DateTime::make('Created At')->sortable(),
             DateTime::make('Updated At')->sortable(),
         ];


### PR DESCRIPTION
Makes users searchable rather than the default (load all into the select).

On dev.

Fixes #969

https://github.com/user-attachments/assets/d979c547-bdf0-4127-bc84-dd0fc121e5bb



