### PR TITLE
fix bg color on body

### DIFF
--- a/resources/assets/js/app.ts
+++ b/resources/assets/js/app.ts
@@ -9,9 +9,9 @@ import router from "./router";
 import store from "./store";
 import axiosClient from "./common/axiosClient";
 import echoClient from "./common/echoClient";
-import "@umn-latis/cla-vue-template/dist/index.css";
 import "../sass/app.scss";
 import "../sass/utils.css";
+import "@umn-latis/cla-vue-template/dist/index.css";
 
 declare global {
   interface Window {


### PR DESCRIPTION
Fixes regression introduced in #975. 

After update to new umn template, the default bg became white instead was white umn off-white due to specificity and order of CSS imports.