### PR TITLE
chore(images): remove unused `getImage` method and endpoint

### DIFF
--- a/app/Http/Controllers/ChimeController.php
+++ b/app/Http/Controllers/ChimeController.php
@@ -255,13 +255,6 @@ class ChimeController extends Controller
       $chime->users()->detach($userId);
       return response('Removed user from Chime', 200);
     }
-   
-  
-    public function getImage(Request $req) {
-        $path = Storage::get('image/'. $req->route('image_name'));
-
-        return Image::make($path)->response();
-    }
 
     public function uploadImage(Request $req) {
         $user = Auth::user();

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,7 +53,6 @@ Route::group(['middleware' => ['shibinjection']], function () {
     Route::delete('/api/chime/{chime_id}/users/{user_id}', [ChimeController::class, 'removeChimeUser']);
 
     Route::get('/api/chime/{chime_id}/response', 'ChimeController@getPastResponses');
-    Route::get('/api/chime/{chime_id}/image/{image_name}', 'ChimeController@getImage');
     Route::post('/api/chime/{chime_id}/image', 'ChimeController@uploadImage');
     Route::post('/api/chime/{chime_id}/folder', 'ChimeController@createFolder');
     Route::put('/api/chime/{chime_id}/folder/{folder_id}', 'ChimeController@editFolder');


### PR DESCRIPTION
The frontend serves images directly via the `/storage` symlink (`public/storage` → `storage/app/public`), so the `getImage()` controller method is never called. It also has a bug. It reads from `storage/app/image` while `uploadImage()` stores to `storage/app/public`.

Removing rather than fixing as prep for migrating Intervention/Image package from v2 to v4.